### PR TITLE
Add per-game streamability badges and Settings icon key

### DIFF
--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -97,7 +97,8 @@ jobs:
             ## CloudPad Beta Release ${{ env.VERSION }}
 
             ### Updates
-            - Added a work-in-progress disclaimer shown on app launch (including right after an update), reminding you to double-check regional/subscription streaming availability via the official PS App
+            - Added streamability badges (check/cross/question mark) to PS5 Library tiles, showing whether a game is known to stream, known not to, or unverified — badges update automatically based on real launch attempts and persist across refreshes and restarts
+            - Added a "PS5 Library Icon Key" section to Settings explaining what each badge icon means
 
             ### APK
             Attached release asset:

--- a/android/app/src/main/java/com/metallic/chiaki/cloudplay/api/PsCloudCatalogService.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/cloudplay/api/PsCloudCatalogService.kt
@@ -320,10 +320,18 @@ class PsCloudCatalogService
 	 * Fetch owned PS5 games for a user (library view), built directly from their entitlements —
 	 * no public catalog cross-reference is needed for a game to show up correctly or stream, so
 	 * there's nothing to hardcode per title. The public catalog is still fetched afterwards on a
-	 * best-effort basis purely to upgrade box art (entitlements only carry a square icon); if
-	 * that fetch fails or a title has no catalog match, the entitlement icon is used as-is.
+	 * best-effort basis to upgrade box art and set the initial streamability badge (entitlements
+	 * only carry a square icon and no streamability signal at all); if that fetch fails or a title
+	 * has no catalog match, the entitlement icon is used as-is and the badge stays UNKNOWN.
+	 *
+	 * @param confirmedStreamableOverrides Real launch-attempt outcomes (productId -> streamable),
+	 * which always win over the catalog-derived guess — see [PsCloudOwnership.applyStreamabilityHints].
 	 */
-	suspend fun fetchOwnedPs5Games(npssoToken: String, locale: String): List<CloudGame>
+	suspend fun fetchOwnedPs5Games(
+		npssoToken: String,
+		locale: String,
+		confirmedStreamableOverrides: Map<String, Boolean> = emptyMap()
+	): List<CloudGame>
 	{
 		if (npssoToken.isEmpty())
 			throw Exception("NPSSO token is required for cloud play.")
@@ -342,12 +350,13 @@ class PsCloudCatalogService
 		val enrichedGames = try
 		{
 			val catalog = fetchPs5CloudCatalog(locale)
-			PsCloudOwnership.enrichWithCatalogArt(ownedGames, catalog.browseGames, catalog.plusLibrarySupplement)
+			val withArt = PsCloudOwnership.enrichWithCatalogArt(ownedGames, catalog.browseGames, catalog.plusLibrarySupplement)
+			PsCloudOwnership.applyStreamabilityHints(withArt, catalog.browseGames, confirmedStreamableOverrides)
 		}
 		catch (e: Exception)
 		{
-			Log.w(TAG, "Failed to enrich owned games with catalog art; using entitlement icons", e)
-			ownedGames
+			Log.w(TAG, "Failed to enrich owned games with catalog data; using entitlement icons and unknown streamability", e)
+			PsCloudOwnership.applyStreamabilityHints(ownedGames, emptyList(), confirmedStreamableOverrides)
 		}
 
 		Log.i(TAG, "  Owned streamable games: ${enrichedGames.size}")

--- a/android/app/src/main/java/com/metallic/chiaki/cloudplay/api/PsCloudOwnership.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/cloudplay/api/PsCloudOwnership.kt
@@ -4,6 +4,7 @@ package com.metallic.chiaki.cloudplay.api
 
 import android.util.Log
 import com.metallic.chiaki.cloudplay.model.CloudGame
+import com.metallic.chiaki.cloudplay.model.StreamableStatus
 import org.json.JSONObject
 
 object PsCloudOwnership
@@ -209,6 +210,45 @@ object PsCloudOwnership
 				landscapeImageUrl = match.landscapeImageUrl.ifEmpty { game.landscapeImageUrl },
 				thumbnailUrl = match.thumbnailUrl.ifEmpty { game.thumbnailUrl }
 			)
+		}
+	}
+
+	/**
+	 * Library tile badge state. A confirmed override (from an actual launch attempt — success or
+	 * a Gaikai-rejected failure) always wins, since it reflects reality rather than a guess and
+	 * should persist until another real attempt changes it. Absent that, a match in Sony's main
+	 * browse catalog (streamingSupported=true, by construction — see mergeImagicCategoryIntoMap)
+	 * is a confident STREAMABLE signal. Everything else — no match, or a match only in the PS
+	 * Plus supplement list (streamingSupported=false, which is sometimes wrong) — is UNKNOWN
+	 * rather than an assumed cross; only a real attempt should ever produce NOT_STREAMABLE.
+	 */
+	fun applyStreamabilityHints(
+		games: List<CloudGame>,
+		catalog: List<CloudGame>,
+		confirmedOverrides: Map<String, Boolean> = emptyMap()
+	): List<CloudGame>
+	{
+		val byProductId = catalogMapFirstWins(catalog)
+		val byStableKey = buildStableKeyIndex(catalog)
+		val byConceptId = buildConceptIdIndex(catalog)
+
+		return games.map { game ->
+			val status = when (confirmedOverrides[game.productId])
+			{
+				true -> StreamableStatus.STREAMABLE
+				false -> StreamableStatus.NOT_STREAMABLE
+				null ->
+				{
+					val stable = productIdStableKey(game.productId)
+					val catalogMatch = byProductId[game.productId]
+						?: byProductId[game.entitlementId]
+						?: byProductId[game.storeProductId]
+						?: stable?.let { byStableKey[it] }
+						?: game.conceptId.takeIf { it.isNotEmpty() }?.let { byConceptId[it] }
+					if (catalogMatch != null) StreamableStatus.STREAMABLE else StreamableStatus.UNKNOWN
+				}
+			}
+			game.copy(streamableStatus = status)
 		}
 	}
 

--- a/android/app/src/main/java/com/metallic/chiaki/cloudplay/model/CloudGame.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/cloudplay/model/CloudGame.kt
@@ -3,6 +3,14 @@
 package com.metallic.chiaki.cloudplay.model
 
 /**
+ * Best-known streamability for a Library game's tile badge.
+ * STREAMABLE/NOT_STREAMABLE can come either from a catalog-derived guess (STREAMABLE only, when
+ * Sony's public catalog confirms streamingSupported=true) or from a real launch attempt, which
+ * always wins over the catalog guess and persists until another real attempt changes it.
+ */
+enum class StreamableStatus { STREAMABLE, NOT_STREAMABLE, UNKNOWN }
+
+/**
  * Represents a game in the cloud catalog (PSNow or PSCloud)
  */
 data class CloudGame(
@@ -19,7 +27,8 @@ data class CloudGame(
 	val entitlementId: String = "", // PSCloud: entitlement id from cross-reference (Qt gameData.id)
 	val storeProductId: String = "", // PSCloud: product_id from entitlements API (stream this, not entitlementId)
 	val plusCatalog: Boolean = false, // In the PS Plus subscription catalog (vs full streamable universe)
-	val featureType: Int = 0 // PSN entitlement feature_type: 3=full game, 1=trial/free, 0=add-on/DLC
+	val featureType: Int = 0, // PSN entitlement feature_type: 3=full game, 1=trial/free, 0=add-on/DLC
+	val streamableStatus: StreamableStatus = StreamableStatus.UNKNOWN // Library tile badge state
 )
 
 /**

--- a/android/app/src/main/java/com/metallic/chiaki/cloudplay/repository/CloudGameRepository.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/cloudplay/repository/CloudGameRepository.kt
@@ -8,6 +8,7 @@ import com.metallic.chiaki.cloudplay.api.PsCloudCatalogService
 import com.metallic.chiaki.cloudplay.api.PsnCatalogService
 import com.metallic.chiaki.cloudplay.model.CloudGame
 import com.metallic.chiaki.cloudplay.model.PsnResult
+import com.metallic.chiaki.cloudplay.model.StreamableStatus
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
@@ -130,7 +131,15 @@ class CloudGameRepository(
 				if (cachedGames != null)
 				{
 					Log.i(TAG, "Returning ${cachedGames.size} owned PS5 games from cache")
-					return@withContext PsnResult.Success(cachedGames)
+					// A launch attempt may have recorded a confirmed override since this cache was
+					// written — reconcile so it still takes effect without needing a full refetch.
+					val overrides = preferences.getConfirmedStreamableOverrides()
+					val reconciled = if (overrides.isEmpty()) cachedGames else cachedGames.map { game ->
+						overrides[game.productId]?.let { streamable ->
+							game.copy(streamableStatus = if (streamable) StreamableStatus.STREAMABLE else StreamableStatus.NOT_STREAMABLE)
+						} ?: game
+					}
+					return@withContext PsnResult.Success(reconciled)
 				}
 			}
 
@@ -138,7 +147,8 @@ class CloudGameRepository(
 			try
 			{
 				val locale = preferences.getCloudStoreLocale().lowercase()
-				val games = pscloudCatalogService.fetchOwnedPs5Games(npssoToken, locale)
+				val overrides = preferences.getConfirmedStreamableOverrides()
+				val games = pscloudCatalogService.fetchOwnedPs5Games(npssoToken, locale, overrides)
 				cacheGames(games, OWNED_CACHE_FILE)
 				PsnResult.Success(games)
 			}
@@ -198,7 +208,12 @@ class CloudGameRepository(
 					entitlementId = entitlementId,
 					storeProductId = obj.optString("storeProductId", ""),
 					plusCatalog = obj.optBoolean("plusCatalog", false),
-					featureType = obj.optInt("featureType", 0)
+					featureType = obj.optInt("featureType", 0),
+					streamableStatus = try {
+						StreamableStatus.valueOf(obj.optString("streamableStatus", "UNKNOWN"))
+					} catch (e: IllegalArgumentException) {
+						StreamableStatus.UNKNOWN
+					}
 				))
 			}
 
@@ -235,6 +250,7 @@ class CloudGameRepository(
 				obj.put("storeProductId", game.storeProductId)
 				obj.put("plusCatalog", game.plusCatalog)
 				obj.put("featureType", game.featureType)
+				obj.put("streamableStatus", game.streamableStatus.name)
 				jsonArray.put(obj)
 			}
 

--- a/android/app/src/main/java/com/metallic/chiaki/common/Preferences.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/common/Preferences.kt
@@ -555,6 +555,7 @@ class Preferences(context: Context)
 	private val LAST_MAIN_TAB_KEY = "last_main_tab"
 	private val CLOUD_SORT_STATE_KEY = "cloud_sort_state"
 	private val FAVORITE_GAMES_KEY = "favorite_games"
+	private val CONFIRMED_STREAMABLE_KEY = "confirmed_streamable_status"
 	private val PSNOW_FILTER_FAVORITES_KEY = "psnow_filter_favorites"
 	private val PSCLOUD_FILTER_FAVORITES_KEY = "pscloud_filter_favorites"
 	private val LICENSE_AGREED_KEY = "license_agreed"
@@ -639,6 +640,37 @@ class Preferences(context: Context)
 	fun isFavoriteGame(productId: String): Boolean
 	{
 		return getFavoriteGames().contains(productId)
+	}
+
+	/**
+	 * Streamability overrides confirmed by an actual launch attempt (success or Gaikai-rejected
+	 * failure), keyed by productId. Takes priority over the catalog-derived best-guess shown
+	 * before any real attempt, and persists across library refreshes and app restarts.
+	 */
+	fun getConfirmedStreamableOverrides(): Map<String, Boolean>
+	{
+		val json = sharedPreferences.getString(CONFIRMED_STREAMABLE_KEY, null) ?: return emptyMap()
+		return try
+		{
+			val obj = org.json.JSONObject(json)
+			val map = mutableMapOf<String, Boolean>()
+			obj.keys().forEach { key -> map[key] = obj.getBoolean(key) }
+			map
+		}
+		catch (e: Exception)
+		{
+			Log.w("Preferences", "Error reading confirmed streamable overrides", e)
+			emptyMap()
+		}
+	}
+
+	fun setConfirmedStreamable(productId: String, streamable: Boolean)
+	{
+		val current = getConfirmedStreamableOverrides().toMutableMap()
+		current[productId] = streamable
+		val obj = org.json.JSONObject()
+		current.forEach { (key, value) -> obj.put(key, value) }
+		sharedPreferences.edit().putString(CONFIRMED_STREAMABLE_KEY, obj.toString()).apply()
 	}
 	
 	// Filter states for favorites

--- a/android/app/src/main/java/com/metallic/chiaki/main/CloudGameAdapter.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/main/CloudGameAdapter.kt
@@ -11,6 +11,7 @@ import coil.load
 import coil.request.CachePolicy
 import com.pylux.stream.R
 import com.metallic.chiaki.cloudplay.model.CloudGame
+import com.metallic.chiaki.cloudplay.model.StreamableStatus
 import com.metallic.chiaki.common.ext.enableFocusableInTouchModeForTv
 import com.pylux.stream.databinding.ItemCloudGameBinding
 
@@ -114,8 +115,18 @@ class CloudGameAdapter(
                     binding.ownershipBadge.text = "Not Owned"
                     binding.ownershipBadge.setBackgroundColor(0xCCFF9800.toInt())
                 }
+
+                binding.streamabilityBadge.visibility = android.view.View.VISIBLE
+                binding.streamabilityIcon.setImageResource(
+                    when (game.streamableStatus) {
+                        StreamableStatus.STREAMABLE -> R.drawable.ic_check_white
+                        StreamableStatus.NOT_STREAMABLE -> R.drawable.ic_close_white
+                        StreamableStatus.UNKNOWN -> R.drawable.ic_question_white
+                    }
+                )
             } else {
                 binding.ownershipBadge.visibility = android.view.View.GONE
+                binding.streamabilityBadge.visibility = android.view.View.GONE
             }
 
             val isFav = isFavorite(game.productId)

--- a/android/app/src/main/java/com/metallic/chiaki/main/CloudPlayFragment.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/main/CloudPlayFragment.kt
@@ -1442,6 +1442,7 @@ class CloudPlayFragment : Fragment() {
                 )
 
                 result.onSuccess { session ->
+                    updateGameStreamability(game, streamable = true)
                     launchCloudStream(session, PsCloudOwnership.streamIdentifier(game))
                 }
 
@@ -1465,6 +1466,7 @@ class CloudPlayFragment : Fragment() {
                     when (error) {
                         is com.metallic.chiaki.cloudplay.api.PsPlusSubscriptionException,
                         is com.metallic.chiaki.cloudplay.api.GameNotStreamableException -> {
+                            updateGameStreamability(game, streamable = false)
                             showStreamingUnavailableErrorDialog(serviceType)
                         }
 
@@ -1481,6 +1483,7 @@ class CloudPlayFragment : Fragment() {
                         }
 
                         else -> {
+                            updateGameStreamability(game, streamable = false)
                             showStreamingUnavailableErrorDialog(serviceType)
                         }
                     }
@@ -1505,6 +1508,7 @@ class CloudPlayFragment : Fragment() {
                 when (e) {
                     is com.metallic.chiaki.cloudplay.api.PsPlusSubscriptionException,
                     is com.metallic.chiaki.cloudplay.api.GameNotStreamableException -> {
+                        updateGameStreamability(game, streamable = false)
                         showStreamingUnavailableErrorDialog(serviceType)
                     }
 
@@ -1521,10 +1525,32 @@ class CloudPlayFragment : Fragment() {
                     }
 
                     else -> {
+                        updateGameStreamability(game, streamable = false)
                         showStreamingUnavailableErrorDialog(serviceType)
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * Records a real launch outcome as the confirmed streamability for this Library tile,
+     * overwriting whatever was there before (catalog guess, unknown, or an earlier attempt) in
+     * either direction, and persists it so it survives future Library refreshes and app restarts.
+     * Scoped to PS Cloud (PS5 Library) only — the badge doesn't apply to PSNow.
+     */
+    private fun updateGameStreamability(game: CloudGame, streamable: Boolean) {
+        if (game.serviceType != "pscloud") return
+
+        preferences.setConfirmedStreamable(game.productId, streamable)
+
+        val newStatus = if (streamable)
+            com.metallic.chiaki.cloudplay.model.StreamableStatus.STREAMABLE
+        else
+            com.metallic.chiaki.cloudplay.model.StreamableStatus.NOT_STREAMABLE
+
+        adapter.games = adapter.games.map {
+            if (it.productId == game.productId) it.copy(streamableStatus = newStatus) else it
         }
     }
 

--- a/android/app/src/main/res/drawable/badge_key_not_streamable.xml
+++ b/android/app/src/main/res/drawable/badge_key_not_streamable.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Standalone composite (circle + glyph) for use as a single Preference icon in the Settings
+     Icon Key section — the in-app Library tile badge is built from two separate views instead. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="32dp"
+        android:height="32dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="?attr/pyluxAccent"
+        android:pathData="M12,0.5A11.5,11.5 0,1,0 12,23.5A11.5,11.5 0,1,0 12,0.5Z"/>
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/android/app/src/main/res/drawable/badge_key_streamable.xml
+++ b/android/app/src/main/res/drawable/badge_key_streamable.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Standalone composite (circle + glyph) for use as a single Preference icon in the Settings
+     Icon Key section — the in-app Library tile badge is built from two separate views instead. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="32dp"
+        android:height="32dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="?attr/pyluxAccent"
+        android:pathData="M12,0.5A11.5,11.5 0,1,0 12,23.5A11.5,11.5 0,1,0 12,0.5Z"/>
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19 21,7l-1.41,-1.41z"/>
+</vector>

--- a/android/app/src/main/res/drawable/badge_key_unknown.xml
+++ b/android/app/src/main/res/drawable/badge_key_unknown.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Standalone composite (circle + glyph) for use as a single Preference icon in the Settings
+     Icon Key section — the in-app Library tile badge is built from two separate views instead. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="32dp"
+        android:height="32dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="?attr/pyluxAccent"
+        android:pathData="M12,0.5A11.5,11.5 0,1,0 12,23.5A11.5,11.5 0,1,0 12,0.5Z"/>
+    <group
+        android:pivotX="12"
+        android:pivotY="13"
+        android:scaleX="1.7"
+        android:scaleY="1.7">
+        <path
+            android:fillColor="#FFFFFFFF"
+            android:pathData="M12,17c-0.55,0 -1,-0.45 -1,-1s0.45,-1 1,-1 1,0.45 1,1 -0.45,1 -1,1zM12.99,13.63c-0.29,0.29 -0.49,0.55 -0.49,1.12h-1.5v-0.38c0,-0.72 0.2,-1.16 0.63,-1.59l0.87,-0.88c0.32,-0.32 0.5,-0.75 0.5,-1.21 0,-0.97 -0.78,-1.75 -1.75,-1.75s-1.75,0.78 -1.75,1.75h-1.5c0,-1.79 1.46,-3.25 3.25,-3.25s3.25,1.46 3.25,3.25c0,0.7 -0.28,1.35 -0.76,1.82z"/>
+    </group>
+</vector>

--- a/android/app/src/main/res/drawable/bg_streamability_circle.xml
+++ b/android/app/src/main/res/drawable/bg_streamability_circle.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="?attr/pyluxAccent" />
+</shape>

--- a/android/app/src/main/res/drawable/ic_check_white.xml
+++ b/android/app/src/main/res/drawable/ic_check_white.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19 21,7l-1.41,-1.41z"/>
+</vector>

--- a/android/app/src/main/res/drawable/ic_question_white.xml
+++ b/android/app/src/main/res/drawable/ic_question_white.xml
@@ -1,0 +1,17 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <!-- Scaled up: the raw glyph only fills a small part of the 24x24 viewport, reading much
+         smaller than the check/cross icons at the same badge size otherwise. -->
+    <group
+        android:pivotX="12"
+        android:pivotY="13"
+        android:scaleX="1.7"
+        android:scaleY="1.7">
+        <path
+            android:fillColor="#FFFFFFFF"
+            android:pathData="M12,17c-0.55,0 -1,-0.45 -1,-1s0.45,-1 1,-1 1,0.45 1,1 -0.45,1 -1,1zM12.99,13.63c-0.29,0.29 -0.49,0.55 -0.49,1.12h-1.5v-0.38c0,-0.72 0.2,-1.16 0.63,-1.59l0.87,-0.88c0.32,-0.32 0.5,-0.75 0.5,-1.21 0,-0.97 -0.78,-1.75 -1.75,-1.75s-1.75,0.78 -1.75,1.75h-1.5c0,-1.79 1.46,-3.25 3.25,-3.25s3.25,1.46 3.25,3.25c0,0.7 -0.28,1.35 -0.76,1.82z"/>
+    </group>
+</vector>

--- a/android/app/src/main/res/layout-land/item_cloud_game.xml
+++ b/android/app/src/main/res/layout-land/item_cloud_game.xml
@@ -68,6 +68,28 @@
             android:paddingTop="8dp"
             android:paddingBottom="8dp">
 
+            <FrameLayout
+                android:id="@+id/streamabilityBadge"
+                android:layout_width="18dp"
+                android:layout_height="18dp"
+                android:layout_marginEnd="6dp"
+                android:visibility="gone">
+
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:background="@drawable/bg_streamability_circle" />
+
+                <ImageView
+                    android:id="@+id/streamabilityIcon"
+                    android:layout_width="11dp"
+                    android:layout_height="11dp"
+                    android:layout_gravity="center"
+                    android:contentDescription="Streamability status"
+                    android:src="@drawable/ic_check_white" />
+
+            </FrameLayout>
+
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/gameNameTextView"
                 android:layout_width="0dp"

--- a/android/app/src/main/res/layout/item_cloud_game.xml
+++ b/android/app/src/main/res/layout/item_cloud_game.xml
@@ -72,6 +72,28 @@
             android:paddingTop="8dp"
             android:paddingBottom="8dp">
 
+            <FrameLayout
+                android:id="@+id/streamabilityBadge"
+                android:layout_width="18dp"
+                android:layout_height="18dp"
+                android:layout_marginEnd="6dp"
+                android:visibility="gone">
+
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:background="@drawable/bg_streamability_circle" />
+
+                <ImageView
+                    android:id="@+id/streamabilityIcon"
+                    android:layout_width="11dp"
+                    android:layout_height="11dp"
+                    android:layout_gravity="center"
+                    android:contentDescription="Streamability status"
+                    android:src="@drawable/ic_check_white" />
+
+            </FrameLayout>
+
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/gameNameTextView"
                 android:layout_width="0dp"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -122,6 +122,10 @@
     <string name="preferences_category_title_about">About</string>
     <string name="preferences_view_license_title">License Agreement</string>
     <string name="preferences_view_license_summary">View license terms and disclaimers</string>
+    <string name="preferences_category_title_icon_key">PS5 Library Icon Key</string>
+    <string name="preferences_icon_key_streamable_title">Game is verified as streamable</string>
+    <string name="preferences_icon_key_not_streamable_title">Game is verified as non-streamable</string>
+    <string name="preferences_icon_key_unknown_title">Game is not verified as streamable or non-streamable. Please launch game to verify status.</string>
     <string name="preferences_registered_hosts_summary">Currently registered: %d</string>
     <string name="preferences_resolution_title">Resolution</string>
     <string name="preferences_fps_title">FPS</string>

--- a/android/app/src/main/res/xml/preferences.xml
+++ b/android/app/src/main/res/xml/preferences.xml
@@ -213,4 +213,26 @@
             app:title="@string/preferences_view_license_title"
             app:icon="@drawable/ic_log"/>
     </PreferenceCategory>
+
+    <PreferenceCategory
+        app:key="category_icon_key"
+        app:title="@string/preferences_category_title_icon_key">
+        <Preference
+            app:key="icon_key_streamable"
+            app:title="@string/preferences_icon_key_streamable_title"
+            app:selectable="false"
+            app:icon="@drawable/badge_key_streamable"/>
+
+        <Preference
+            app:key="icon_key_not_streamable"
+            app:title="@string/preferences_icon_key_not_streamable_title"
+            app:selectable="false"
+            app:icon="@drawable/badge_key_not_streamable"/>
+
+        <Preference
+            app:key="icon_key_unknown"
+            app:title="@string/preferences_icon_key_unknown_title"
+            app:selectable="false"
+            app:icon="@drawable/badge_key_unknown"/>
+    </PreferenceCategory>
 </PreferenceScreen>

--- a/android/app/src/test/java/com/metallic/chiaki/cloudplay/api/PsCloudOwnershipTest.kt
+++ b/android/app/src/test/java/com/metallic/chiaki/cloudplay/api/PsCloudOwnershipTest.kt
@@ -1,6 +1,7 @@
 package com.metallic.chiaki.cloudplay.api
 
 import com.metallic.chiaki.cloudplay.model.CloudGame
+import com.metallic.chiaki.cloudplay.model.StreamableStatus
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -835,5 +836,73 @@ class PsCloudOwnershipTest {
         )
 
         assertEquals("https://cover/classic-re2.jpg", result.first().imageUrl)
+    }
+
+    // --- applyStreamabilityHints: Library tile badge derivation
+
+    @Test
+    fun `catalog match sets STREAMABLE`() {
+        val owned = CloudGame(
+            productId = "PPSA00001_00", name = "Some Game", imageUrl = "", platform = "ps5", serviceType = "pscloud"
+        )
+        val catalogEntry = CloudGame(
+            productId = "PPSA00001_00", name = "Some Game", imageUrl = "", platform = "ps5", serviceType = "pscloud"
+        )
+
+        val result = PsCloudOwnership.applyStreamabilityHints(listOf(owned), listOf(catalogEntry))
+
+        assertEquals(StreamableStatus.STREAMABLE, result.first().streamableStatus)
+    }
+
+    @Test
+    fun `no catalog match and no confirmed override is UNKNOWN, not an assumed cross`() {
+        val owned = CloudGame(
+            productId = "PPSA00001_00", name = "Some Game", imageUrl = "", platform = "ps5", serviceType = "pscloud"
+        )
+
+        val result = PsCloudOwnership.applyStreamabilityHints(listOf(owned), catalog = emptyList())
+
+        assertEquals(StreamableStatus.UNKNOWN, result.first().streamableStatus)
+    }
+
+    @Test
+    fun `confirmed override wins over a catalog match`() {
+        val owned = CloudGame(
+            productId = "PPSA00001_00", name = "Some Game", imageUrl = "", platform = "ps5", serviceType = "pscloud"
+        )
+        val catalogEntry = owned.copy()
+
+        val result = PsCloudOwnership.applyStreamabilityHints(
+            listOf(owned), listOf(catalogEntry), confirmedOverrides = mapOf("PPSA00001_00" to false)
+        )
+
+        // A real failed launch attempt overrides even a confident catalog "streamable" match.
+        assertEquals(StreamableStatus.NOT_STREAMABLE, result.first().streamableStatus)
+    }
+
+    @Test
+    fun `confirmed streamable override applies even with no catalog match at all`() {
+        val owned = CloudGame(
+            productId = "PPSA00001_00", name = "Some Game", imageUrl = "", platform = "ps5", serviceType = "pscloud"
+        )
+
+        val result = PsCloudOwnership.applyStreamabilityHints(
+            listOf(owned), catalog = emptyList(), confirmedOverrides = mapOf("PPSA00001_00" to true)
+        )
+
+        assertEquals(StreamableStatus.STREAMABLE, result.first().streamableStatus)
+    }
+
+    @Test
+    fun `unrelated confirmed overrides do not affect other games`() {
+        val gameA = CloudGame(productId = "PPSA00001_00", name = "Game A", imageUrl = "", platform = "ps5", serviceType = "pscloud")
+        val gameB = CloudGame(productId = "PPSA00002_00", name = "Game B", imageUrl = "", platform = "ps5", serviceType = "pscloud")
+
+        val result = PsCloudOwnership.applyStreamabilityHints(
+            listOf(gameA, gameB), catalog = emptyList(), confirmedOverrides = mapOf("PPSA00001_00" to false)
+        )
+
+        assertEquals(StreamableStatus.NOT_STREAMABLE, result.first { it.productId == "PPSA00001_00" }.streamableStatus)
+        assertEquals(StreamableStatus.UNKNOWN, result.first { it.productId == "PPSA00002_00" }.streamableStatus)
     }
 }


### PR DESCRIPTION
Library tiles now show a check/cross/question-mark badge indicating whether a PS5 game is known to stream, known not to, or unverified. Catalog matches are marked streamable; unmatched games start as unknown (never an assumed cross) and the badge is corrected in either direction based on real launch attempts, persisting across refreshes and app restarts. Adds a "PS5 Library Icon Key" section to Settings explaining what each badge means.