### PR TITLE
Add game playtime tracking and Recently Played sort

### DIFF
--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -97,8 +97,8 @@ jobs:
             ## CloudPad Beta Release ${{ env.VERSION }}
 
             ### Updates
-            - Added streamability badges (check/cross/question mark) to PS5 Library tiles, showing whether a game is known to stream, known not to, or unverified — badges update automatically based on real launch attempts and persist across refreshes and restarts
-            - Added a "PS5 Library Icon Key" section to Settings explaining what each badge icon means
+            - Added a "Recently Played" sort option for PS3 Catalog, PS4 Catalog and PS5 Library
+            - Added a Playtime screen (long-press a game → Playtime) showing total playtime, last played date, and longest session, tracked automatically across all three platforms
 
             ### APK
             Attached release asset:

--- a/android/app/src/main/java/com/metallic/chiaki/cloudplay/CloudConnectInfoBuilder.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/cloudplay/CloudConnectInfoBuilder.kt
@@ -14,7 +14,7 @@ import com.metallic.chiaki.lib.ConnectVideoProfile
  */
 object CloudConnectInfoBuilder
 {
-	fun build(session: CloudStreamSession, preferences: Preferences, gameIdentifier: String): ConnectInfo
+	fun build(session: CloudStreamSession, preferences: Preferences, gameIdentifier: String, gameProductId: String? = null): ConnectInfo
 	{
 		// Set codec based on service type (Qt lines 344-353): PSCLOUD: H.265/HEVC, PSNOW: H.264
 		val codec = if(session.serviceType == "pscloud") Codec.CODEC_H265 else Codec.CODEC_H264
@@ -63,7 +63,8 @@ object CloudConnectInfoBuilder
 			cloudRttUs = session.rttMs.toLong() * 1000L, // Convert ms to microseconds
 			cloudGameIdentifier = gameIdentifier,
 			cloudGameName = session.gameName,
-			cloudOwnedEntitlementId = session.entitlementId
+			cloudOwnedEntitlementId = session.entitlementId,
+			cloudGameProductId = gameProductId
 		)
 	}
 }

--- a/android/app/src/main/java/com/metallic/chiaki/cloudplay/model/GamePlaytimeStats.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/cloudplay/model/GamePlaytimeStats.kt
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
+
+package com.metallic.chiaki.cloudplay.model
+
+/**
+ * Accumulated playtime for a single game, keyed by [CloudGame.productId] in [com.metallic.chiaki.common.Preferences].
+ * Updated once per stream disconnect with the duration of the session that just ended.
+ */
+data class GamePlaytimeStats(
+	val totalPlaytimeMs: Long = 0L,
+	val lastPlayedMs: Long = 0L,
+	val longestSessionMs: Long = 0L
+)

--- a/android/app/src/main/java/com/metallic/chiaki/cloudplay/model/PlaytimeFormatter.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/cloudplay/model/PlaytimeFormatter.kt
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
+
+package com.metallic.chiaki.cloudplay.model
+
+/** Pure formatting helpers for the Playtime dialog — split out from CloudPlayFragment so the
+ *  duration math (day/hour/minute breakdown, rounding) can be unit tested without Robolectric. */
+object PlaytimeFormatter
+{
+	/** e.g. "2d 4h 15m", or "0h 5m" for durations under a day, or "Not yet played" for 0/negative. */
+	fun formatTotalPlaytime(ms: Long): String
+	{
+		if (ms <= 0L) return "Not yet played"
+		val totalMinutes = ms / 60_000L
+		val days = totalMinutes / (24 * 60)
+		val hours = (totalMinutes % (24 * 60)) / 60
+		val minutes = totalMinutes % 60
+		return buildString {
+			if (days > 0) append("${days}d ")
+			if (days > 0 || hours > 0) append("${hours}h ")
+			append("${minutes}m")
+		}
+	}
+
+	/** e.g. "3h 20m", or "45m" for sessions under an hour, or "Not yet played" for 0/negative. */
+	fun formatSessionDuration(ms: Long): String
+	{
+		if (ms <= 0L) return "Not yet played"
+		val totalMinutes = ms / 60_000L
+		val hours = totalMinutes / 60
+		val minutes = totalMinutes % 60
+		return if (hours > 0) "${hours}h ${minutes}m" else "${minutes}m"
+	}
+}

--- a/android/app/src/main/java/com/metallic/chiaki/common/Preferences.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/common/Preferences.kt
@@ -7,6 +7,7 @@ import android.content.SharedPreferences
 import android.util.Log
 import androidx.annotation.StringRes
 import androidx.preference.PreferenceManager
+import com.metallic.chiaki.cloudplay.model.GamePlaytimeStats
 import com.metallic.chiaki.cloudplay.repository.CloudGameRepository
 import com.pylux.stream.R
 import com.metallic.chiaki.lib.Codec
@@ -560,6 +561,7 @@ class Preferences(context: Context)
 	private val PSCLOUD_FILTER_FAVORITES_KEY = "pscloud_filter_favorites"
 	private val LICENSE_AGREED_KEY = "license_agreed"
 	private val TOTAL_STREAM_TIME_MS_KEY = "total_stream_time_ms"
+	private val GAME_PLAYTIME_KEY = "game_playtime_stats"
 	/** Migrated from one-time flag; removed after [lastDonationPromptWallClockMs] is seeded. */
 	private val DONATION_STREAM_AUTO_PROMPT_SHOWN_KEY = "donation_stream_auto_prompt_shown"
 	private val LAST_DONATION_PROMPT_WALL_MS_KEY = "last_donation_prompt_wall_ms"
@@ -609,7 +611,7 @@ class Preferences(context: Context)
 	
 	fun getCloudSortState(): Int
 	{
-		return sharedPreferences.getInt(CLOUD_SORT_STATE_KEY, 0) // Default to Recent (0)
+		return sharedPreferences.getInt(CLOUD_SORT_STATE_KEY, 0) // Default to Name: A→Z (0)
 	}
 	
 	fun setCloudSortState(sortState: Int)
@@ -672,7 +674,66 @@ class Preferences(context: Context)
 		current.forEach { (key, value) -> obj.put(key, value) }
 		sharedPreferences.edit().putString(CONFIRMED_STREAMABLE_KEY, obj.toString()).apply()
 	}
-	
+
+	/**
+	 * Per-game playtime stats (PS3/PS4 Catalog and PS5 Library), keyed by [CloudGame.productId].
+	 * Written by [recordPlaySession] once per stream disconnect (see StreamActivity.flushStreamTimeSegment).
+	 */
+	fun getGamePlaytimeStats(): Map<String, GamePlaytimeStats>
+	{
+		val json = sharedPreferences.getString(GAME_PLAYTIME_KEY, null) ?: return emptyMap()
+		return try
+		{
+			val obj = org.json.JSONObject(json)
+			val map = mutableMapOf<String, GamePlaytimeStats>()
+			obj.keys().forEach { key ->
+				val entry = obj.getJSONObject(key)
+				map[key] = GamePlaytimeStats(
+					totalPlaytimeMs = entry.optLong("totalPlaytimeMs", 0L),
+					lastPlayedMs = entry.optLong("lastPlayedMs", 0L),
+					longestSessionMs = entry.optLong("longestSessionMs", 0L)
+				)
+			}
+			map
+		}
+		catch (e: Exception)
+		{
+			Log.w("Preferences", "Error reading game playtime stats", e)
+			emptyMap()
+		}
+	}
+
+	fun getGamePlaytimeStats(productId: String): GamePlaytimeStats? = getGamePlaytimeStats()[productId]
+
+	fun getLastPlayedMs(productId: String): Long = getGamePlaytimeStats(productId)?.lastPlayedMs ?: 0L
+
+	/**
+	 * Records a completed play session against [productId] — accumulates total playtime, bumps
+	 * the longest single session if this one was longer, and overwrites the last-played timestamp.
+	 */
+	fun recordPlaySession(productId: String, sessionDurationMs: Long, sessionStartedWallClockMs: Long)
+	{
+		if (sessionDurationMs <= 0L) return
+
+		val current = getGamePlaytimeStats().toMutableMap()
+		val existing = current[productId]
+		current[productId] = GamePlaytimeStats(
+			totalPlaytimeMs = (existing?.totalPlaytimeMs ?: 0L) + sessionDurationMs,
+			lastPlayedMs = sessionStartedWallClockMs,
+			longestSessionMs = maxOf(existing?.longestSessionMs ?: 0L, sessionDurationMs)
+		)
+
+		val obj = org.json.JSONObject()
+		current.forEach { (key, stats) ->
+			val entryObj = org.json.JSONObject()
+			entryObj.put("totalPlaytimeMs", stats.totalPlaytimeMs)
+			entryObj.put("lastPlayedMs", stats.lastPlayedMs)
+			entryObj.put("longestSessionMs", stats.longestSessionMs)
+			obj.put(key, entryObj)
+		}
+		sharedPreferences.edit().putString(GAME_PLAYTIME_KEY, obj.toString()).apply()
+	}
+
 	// Filter states for favorites
 	fun getPsnowFilterFavorites(): Boolean
 	{

--- a/android/app/src/main/java/com/metallic/chiaki/lib/Chiaki.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/lib/Chiaki.kt
@@ -88,6 +88,10 @@ data class ConnectInfo(
 	val cloudGameIdentifier: String? = null,
 	val cloudGameName: String? = null,
 	val cloudOwnedEntitlementId: String? = null,
+	// Stable CloudGame.productId for this session's game — kept separate from
+	// cloudGameIdentifier (which may be a normalized/rescued stream identifier) so playtime
+	// tracking keys against the same productId used by favorites/streamability overrides.
+	val cloudGameProductId: String? = null,
 	// PSN Remote Play fields (for holepunch connections)
 	val duid: String? = null,
 	val psnToken: String? = null,

--- a/android/app/src/main/java/com/metallic/chiaki/main/CloudGameAdapter.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/main/CloudGameAdapter.kt
@@ -2,7 +2,6 @@
 
 package com.metallic.chiaki.main
 
-import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
@@ -19,6 +18,7 @@ class CloudGameAdapter(
     private val onGameClick: (CloudGame) -> Unit,
     private val onFavoriteClick: (CloudGame, Boolean) -> Unit,
     private val onAddShortcutClick: (CloudGame) -> Unit,
+    private val onPlaytimeClick: (CloudGame) -> Unit,
     private val isFavorite: (String) -> Boolean
 ) : RecyclerView.Adapter<CloudGameAdapter.CloudGameViewHolder>() {
     init {
@@ -31,7 +31,7 @@ class CloudGameAdapter(
             notifyDataSetChanged()
         }
 
-    var showOwnershipBadge: Boolean = false
+    var showStreamabilityBadge: Boolean = false
         set(value) {
             field = value
             notifyDataSetChanged()
@@ -104,18 +104,7 @@ class CloudGameAdapter(
                 else -> game.platform.takeLast(1)
             }
 
-            if (showOwnershipBadge && game.serviceType == "pscloud") {
-                binding.ownershipBadge.visibility = android.view.View.VISIBLE
-                if (game.isOwned) {
-                    binding.ownershipBadge.text = "Owned"
-                    val tv = TypedValue()
-                    binding.ownershipBadge.context.theme.resolveAttribute(R.attr.pyluxAccentA80, tv, true)
-                    binding.ownershipBadge.setBackgroundColor(tv.data)
-                } else {
-                    binding.ownershipBadge.text = "Not Owned"
-                    binding.ownershipBadge.setBackgroundColor(0xCCFF9800.toInt())
-                }
-
+            if (showStreamabilityBadge && game.serviceType == "pscloud") {
                 binding.streamabilityBadge.visibility = android.view.View.VISIBLE
                 binding.streamabilityIcon.setImageResource(
                     when (game.streamableStatus) {
@@ -125,7 +114,6 @@ class CloudGameAdapter(
                     }
                 )
             } else {
-                binding.ownershipBadge.visibility = android.view.View.GONE
                 binding.streamabilityBadge.visibility = android.view.View.GONE
             }
 
@@ -181,6 +169,13 @@ class CloudGameAdapter(
                     "Add to Home Screen"
                 )
 
+                popup.menu.add(
+                    0,
+                    3,
+                    2,
+                    "Playtime"
+                )
+
                 popup.setOnMenuItemClickListener { item ->
                     when (item.itemId) {
                         1 -> {
@@ -193,6 +188,11 @@ class CloudGameAdapter(
                             true
                         }
 
+                        3 -> {
+                            onPlaytimeClick(game)
+                            true
+                        }
+
                         else -> false
                     }
                 }
@@ -201,13 +201,20 @@ class CloudGameAdapter(
                 true
             }
             binding.root.setOnKeyListener { _, keyCode, event ->
-                if (event.action == android.view.KeyEvent.ACTION_DOWN &&
-                    keyCode == android.view.KeyEvent.KEYCODE_MENU
-                ) {
-                    toggleFavorite()
-                    true
-                } else {
+                if (event.action != android.view.KeyEvent.ACTION_DOWN) {
                     false
+                } else when (keyCode) {
+                    android.view.KeyEvent.KEYCODE_MENU -> {
+                        toggleFavorite()
+                        true
+                    }
+                    // Square on PlayStation controllers reports as the generic gamepad "X" keycode
+                    // on Android (X/Y/A/B are positional, not brand-specific).
+                    android.view.KeyEvent.KEYCODE_BUTTON_X -> {
+                        onPlaytimeClick(game)
+                        true
+                    }
+                    else -> false
                 }
             }
         }

--- a/android/app/src/main/java/com/metallic/chiaki/main/CloudPlayFragment.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/main/CloudPlayFragment.kt
@@ -596,7 +596,7 @@ class CloudPlayFragment : Fragment() {
         binding.ownedToggleButton.visibility = android.view.View.GONE
 
         viewModel.setCurrentSection("psnow_ps3")
-        adapter.showOwnershipBadge = false
+        adapter.showStreamabilityBadge = false
         binding.sortOptionLayout.visibility = android.view.View.VISIBLE
         binding.filterOptionLayout.visibility = android.view.View.VISIBLE
         updateSortButtonText()
@@ -614,7 +614,7 @@ class CloudPlayFragment : Fragment() {
         binding.ownedToggleButton.visibility = android.view.View.GONE
 
         viewModel.setCurrentSection("psnow_ps4")
-        adapter.showOwnershipBadge = false
+        adapter.showStreamabilityBadge = false
         binding.sortOptionLayout.visibility = android.view.View.VISIBLE
         binding.filterOptionLayout.visibility = android.view.View.VISIBLE
         updateSortButtonText()
@@ -633,7 +633,7 @@ class CloudPlayFragment : Fragment() {
         preferences.setPsCloudFilterOwned(true)
 
         viewModel.setCurrentSection("pscloud")
-        adapter.showOwnershipBadge = true
+        adapter.showStreamabilityBadge = true
         binding.sortOptionLayout.visibility = android.view.View.VISIBLE
         binding.filterOptionLayout.visibility = android.view.View.VISIBLE
         updateSortButtonText()
@@ -690,11 +690,7 @@ class CloudPlayFragment : Fragment() {
 
 
     private fun showSortMenu() {
-        val currentSection = viewModel.getCurrentSection()
-        val sortOptions = when (currentSection) {
-            "pscloud" -> arrayOf("Owned First", "Name: A → Z", "Name: Z → A")
-            else -> arrayOf("Recent", "Name: A → Z", "Name: Z → A")
-        }
+        val sortOptions = arrayOf("Name: A → Z", "Name: Z → A", "Recently Played")
 
         requireContext().alertDialogBuilder()
             .setTitle("Sort")
@@ -750,17 +746,11 @@ class CloudPlayFragment : Fragment() {
     private fun showSortMenu(anchor: android.view.View) {
         expandSettingsFab(false)
 
-        val currentSection = viewModel.getCurrentSection()
         val popup = androidx.appcompat.widget.PopupMenu(requireContext(), anchor)
 
-        // Different default sort for Library vs Catalog
-        if (currentSection == "pscloud") {
-            popup.menu.add(0, 0, 0, "Owned First (Default)")
-        } else {
-            popup.menu.add(0, 0, 0, "Recent (Default)")
-        }
-        popup.menu.add(0, 1, 1, "Name: A → Z")
-        popup.menu.add(0, 2, 2, "Name: Z → A")
+        popup.menu.add(0, 0, 0, "Name: A → Z (Default)")
+        popup.menu.add(0, 1, 1, "Name: Z → A")
+        popup.menu.add(0, 2, 2, "Recently Played")
 
         // Highlight current selection with radio button style
         popup.menu.findItem(sortState)?.isChecked = true
@@ -780,44 +770,34 @@ class CloudPlayFragment : Fragment() {
         updateSortButtonText()
 
         val currentGames = viewModel.games.value ?: return
-        val currentSection = viewModel.getCurrentSection()
 
         when (sortState) {
             0 -> {
-                // Default: Different behavior for Library vs Catalog
-                if (currentSection == "pscloud") {
-                    // Library: Sort by ownership (owned first), then maintain order
-                    val sortedGames = currentGames.sortedWith(
-                        compareByDescending<CloudGame> { it.isOwned }
-                    )
-                    viewModel.setSortedGames(sortedGames)
-                } else {
-                    // Catalog: Reload from cache to restore original API order
-                    viewModel.fetchPsnowCatalog(forceRefresh = false)
-                }
-            }
-
-            1 -> {
-                // A->Z
+                // A->Z (default)
                 val sortedGames = currentGames.sortedBy { it.name.lowercase() }
                 viewModel.setSortedGames(sortedGames)
             }
 
-            2 -> {
+            1 -> {
                 // Z->A
                 val sortedGames = currentGames.sortedByDescending { it.name.lowercase() }
+                viewModel.setSortedGames(sortedGames)
+            }
+
+            2 -> {
+                // Recently Played
+                val sortedGames = currentGames.sortedByDescending { preferences.getLastPlayedMs(it.productId) }
                 viewModel.setSortedGames(sortedGames)
             }
         }
     }
 
     private fun updateSortButtonText() {
-        val currentSection = viewModel.getCurrentSection()
         val text = when (sortState) {
-            0 -> if (currentSection == "pscloud") "Sort: Owned" else "Sort: Recent"
-            1 -> "Sort: A→Z"
-            2 -> "Sort: Z→A"
-            else -> if (currentSection == "pscloud") "Sort: Owned" else "Sort: Recent"
+            0 -> "Sort: A→Z"
+            1 -> "Sort: Z→A"
+            2 -> "Sort: Recently Played"
+            else -> "Sort: A→Z"
         }
         binding.sortLabelButton.text = text
     }
@@ -920,9 +900,9 @@ class CloudPlayFragment : Fragment() {
 
         // Apply current sort state
         val sortedGames = when (sortState) {
-            1 -> favoriteGames.sortedBy { it.name.lowercase() }
-            2 -> favoriteGames.sortedByDescending { it.name.lowercase() }
-            else -> favoriteGames
+            1 -> favoriteGames.sortedByDescending { it.name.lowercase() }
+            2 -> favoriteGames.sortedByDescending { preferences.getLastPlayedMs(it.productId) }
+            else -> favoriteGames.sortedBy { it.name.lowercase() }
         }
 
         adapter.games = sortedGames
@@ -945,11 +925,56 @@ class CloudPlayFragment : Fragment() {
         }
     }
 
+    /** Shown from the long-press "Playtime" menu item — works for PS3/PS4 Catalog and PS5
+     *  Library games alike since both accumulate stats under the same productId key
+     *  (see StreamActivity.flushStreamTimeSegment / Preferences.recordPlaySession). */
+    private fun showPlaytimeDialog(game: CloudGame) {
+        val stats = preferences.getGamePlaytimeStats(game.productId)
+
+        val view = LayoutInflater.from(requireContext()).inflate(R.layout.dialog_playtime, null)
+        view.findViewById<TextView>(R.id.playtimeGameTitle).text = game.name
+
+        val artImageView = view.findViewById<ImageView>(R.id.playtimeGameArt)
+        if (game.imageUrl.isNotEmpty()) {
+            artImageView.load(game.imageUrl) {
+                crossfade(true)
+                error(android.R.drawable.ic_menu_gallery)
+            }
+        } else {
+            artImageView.setImageResource(android.R.drawable.ic_menu_gallery)
+        }
+
+        view.findViewById<TextView>(R.id.playtimeTotalText).text =
+            "Total Playtime: ${com.metallic.chiaki.cloudplay.model.PlaytimeFormatter.formatTotalPlaytime(stats?.totalPlaytimeMs ?: 0L)}"
+        view.findViewById<TextView>(R.id.playtimeLastPlayedText).text =
+            "Last Played: ${formatLastPlayed(stats?.lastPlayedMs ?: 0L)}"
+        view.findViewById<TextView>(R.id.playtimeLongestSessionText).text =
+            "Longest Session: ${com.metallic.chiaki.cloudplay.model.PlaytimeFormatter.formatSessionDuration(stats?.longestSessionMs ?: 0L)}"
+
+        val dialog = requireContext().alertDialogBuilder()
+            .setView(view)
+            .setPositiveButton("Close", null)
+            .create()
+        // Border on the window itself, not just the content view, matching the disclaimer dialog.
+        dialog.window?.setBackgroundDrawableResource(R.drawable.bg_disclaimer_box)
+        dialog.show()
+    }
+
+    private fun formatLastPlayed(ms: Long): String {
+        if (ms <= 0L) return "Never"
+        val format = java.text.DateFormat.getDateTimeInstance(
+            java.text.DateFormat.MEDIUM,
+            java.text.DateFormat.SHORT
+        )
+        return format.format(java.util.Date(ms))
+    }
+
     private fun setupRecyclerView() {
         adapter = CloudGameAdapter(
             onGameClick = this::onGameClicked,
             onFavoriteClick = this::onGameFavoriteToggled,
             onAddShortcutClick = this::onAddShortcutClicked,
+            onPlaytimeClick = this::showPlaytimeDialog,
             isFavorite = { productId -> preferences.isFavoriteGame(productId) }
         )
         binding.gamesRecyclerView.adapter = adapter
@@ -1052,18 +1077,9 @@ class CloudPlayFragment : Fragment() {
 
             // Apply saved sort state when games are loaded
             val sortedGames = when (sortState) {
-                0 -> {
-                    // Default sort: Owned first for Library, original order for Catalog
-                    if (currentSection == "pscloud") {
-                        filteredGames.sortedWith(compareByDescending { it.isOwned })
-                    } else {
-                        filteredGames
-                    }
-                }
-
-                1 -> filteredGames.sortedBy { it.name.lowercase() } // A->Z
-                2 -> filteredGames.sortedByDescending { it.name.lowercase() } // Z->A
-                else -> filteredGames
+                1 -> filteredGames.sortedByDescending { it.name.lowercase() } // Z->A
+                2 -> filteredGames.sortedByDescending { preferences.getLastPlayedMs(it.productId) } // Recently Played
+                else -> filteredGames.sortedBy { it.name.lowercase() } // A->Z (default)
             }
 
             adapter.games = sortedGames
@@ -1443,7 +1459,7 @@ class CloudPlayFragment : Fragment() {
 
                 result.onSuccess { session ->
                     updateGameStreamability(game, streamable = true)
-                    launchCloudStream(session, PsCloudOwnership.streamIdentifier(game))
+                    launchCloudStream(session, PsCloudOwnership.streamIdentifier(game), game.productId)
                 }
 
                 result.onFailure { error ->
@@ -1622,12 +1638,12 @@ class CloudPlayFragment : Fragment() {
     /**
      * Launch StreamActivity with cloud stream session
      */
-    private fun launchCloudStream(session: com.metallic.chiaki.cloudplay.model.CloudStreamSession, gameIdentifier: String) {
+    private fun launchCloudStream(session: com.metallic.chiaki.cloudplay.model.CloudStreamSession, gameIdentifier: String, gameProductId: String? = null) {
 
         // ConnectInfo building (codec/resolution/bitrate selection) lives in
         // CloudConnectInfoBuilder so the in-stream Quick Settings "refresh" action can build
         // an identical ConnectInfo when re-allocating a session for the same game later.
-        val connectInfo = com.metallic.chiaki.cloudplay.CloudConnectInfoBuilder.build(session, preferences, gameIdentifier)
+        val connectInfo = com.metallic.chiaki.cloudplay.CloudConnectInfoBuilder.build(session, preferences, gameIdentifier, gameProductId)
 
         // Launch StreamActivity
         val intent = android.content.Intent(

--- a/android/app/src/main/java/com/metallic/chiaki/stream/StreamActivity.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/stream/StreamActivity.kt
@@ -80,6 +80,11 @@ class StreamActivity : AppCompatActivity(), View.OnSystemUiVisibilityChangeListe
 	/** [SystemClock.elapsedRealtime] when this session entered [StreamStateConnected]; 0 if not connected. */
 	private var connectedAtElapsedRealtime: Long = 0L
 
+	/** Wall-clock counterpart of [connectedAtElapsedRealtime], used as the "last played" timestamp
+	 *  recorded against the game once the segment is flushed (elapsedRealtime is boot-relative and
+	 *  not meaningful to persist/display). 0 if not connected. */
+	private var connectedAtWallClockMs: Long = 0L
+
 	/** Currently-applied window size / display mode. Only changes when the Quick Settings
 	 *  panel's Save button is pressed — the panel's own toggle group is staged separately. */
 	private var currentDisplayMode: TransformMode = TransformMode.FIT
@@ -369,8 +374,14 @@ class StreamActivity : AppCompatActivity(), View.OnSystemUiVisibilityChangeListe
 		if (connectedAtElapsedRealtime == 0L) return
 		val delta = SystemClock.elapsedRealtime() - connectedAtElapsedRealtime
 		if (delta > 0L)
+		{
 			viewModel.preferences.addTotalStreamTimeMs(delta)
+			viewModel.connectInfo.cloudGameProductId?.let { productId ->
+				viewModel.preferences.recordPlaySession(productId, delta, connectedAtWallClockMs)
+			}
+		}
 		connectedAtElapsedRealtime = 0L
+		connectedAtWallClockMs = 0L
 	}
 
 	private fun stateChanged(state: StreamState)
@@ -383,7 +394,10 @@ class StreamActivity : AppCompatActivity(), View.OnSystemUiVisibilityChangeListe
 			StreamStateConnected ->
 			{
 				if (connectedAtElapsedRealtime == 0L)
+				{
 					connectedAtElapsedRealtime = SystemClock.elapsedRealtime()
+					connectedAtWallClockMs = System.currentTimeMillis()
+				}
 			}
 
 			StreamStateConnecting ->

--- a/android/app/src/main/res/layout-land/item_cloud_game.xml
+++ b/android/app/src/main/res/layout-land/item_cloud_game.xml
@@ -39,22 +39,28 @@
             android:focusable="false"
             android:scaleType="fitCenter" />
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/ownershipBadge"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+        <FrameLayout
+            android:id="@+id/streamabilityBadge"
+            android:layout_width="22dp"
+            android:layout_height="22dp"
             android:layout_gravity="top|end"
             android:layout_margin="6dp"
-            android:paddingStart="6dp"
-            android:paddingEnd="6dp"
-            android:paddingTop="2dp"
-            android:paddingBottom="2dp"
-            android:text="Owned"
-            android:textSize="9sp"
-            android:textStyle="bold"
-            android:textColor="#FFFFFF"
-            android:background="?attr/pyluxAccentA30"
-            android:visibility="gone" />
+            android:visibility="gone">
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@drawable/bg_streamability_circle" />
+
+            <ImageView
+                android:id="@+id/streamabilityIcon"
+                android:layout_width="14dp"
+                android:layout_height="14dp"
+                android:layout_gravity="center"
+                android:contentDescription="Streamability status"
+                android:src="@drawable/ic_check_white" />
+
+        </FrameLayout>
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -67,28 +73,6 @@
             android:paddingEnd="8dp"
             android:paddingTop="8dp"
             android:paddingBottom="8dp">
-
-            <FrameLayout
-                android:id="@+id/streamabilityBadge"
-                android:layout_width="18dp"
-                android:layout_height="18dp"
-                android:layout_marginEnd="6dp"
-                android:visibility="gone">
-
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:background="@drawable/bg_streamability_circle" />
-
-                <ImageView
-                    android:id="@+id/streamabilityIcon"
-                    android:layout_width="11dp"
-                    android:layout_height="11dp"
-                    android:layout_gravity="center"
-                    android:contentDescription="Streamability status"
-                    android:src="@drawable/ic_check_white" />
-
-            </FrameLayout>
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/gameNameTextView"

--- a/android/app/src/main/res/layout/dialog_playtime.xml
+++ b/android/app/src/main/res/layout/dialog_playtime.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- No background here — the theme-coloured border is applied to the dialog window itself
+     (see CloudPlayFragment.showPlaytimeDialog), matching dialog_disclaimer's convention. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="20dp">
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/playtimeGameArtCard"
+            android:layout_width="56dp"
+            android:layout_height="56dp"
+            android:layout_alignParentEnd="true"
+            app:cardCornerRadius="8dp"
+            app:cardElevation="0dp">
+
+            <ImageView
+                android:id="@+id/playtimeGameArt"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:scaleType="centerCrop"
+                android:contentDescription="@null" />
+
+        </com.google.android.material.card.MaterialCardView>
+
+        <TextView
+            android:id="@+id/playtimeGameTitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_toStartOf="@id/playtimeGameArtCard"
+            android:layout_marginEnd="12dp"
+            android:layout_centerVertical="true"
+            android:gravity="center"
+            android:textColor="?attr/pyluxAccent"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+
+    </RelativeLayout>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginBottom="16dp"
+        android:background="?attr/pyluxAccent"
+        android:alpha="0.3" />
+
+    <TextView
+        android:id="@+id/playtimeTotalText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textColor="@android:color/white"
+        android:textSize="14sp" />
+
+    <TextView
+        android:id="@+id/playtimeLastPlayedText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:textColor="@android:color/white"
+        android:textSize="14sp" />
+
+    <TextView
+        android:id="@+id/playtimeLongestSessionText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:textColor="@android:color/white"
+        android:textSize="14sp" />
+
+</LinearLayout>

--- a/android/app/src/main/res/layout/item_cloud_game.xml
+++ b/android/app/src/main/res/layout/item_cloud_game.xml
@@ -43,22 +43,28 @@
             android:focusable="false"
             android:scaleType="fitCenter" />
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/ownershipBadge"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+        <FrameLayout
+            android:id="@+id/streamabilityBadge"
+            android:layout_width="22dp"
+            android:layout_height="22dp"
             android:layout_gravity="top|end"
             android:layout_margin="6dp"
-            android:paddingStart="6dp"
-            android:paddingEnd="6dp"
-            android:paddingTop="2dp"
-            android:paddingBottom="2dp"
-            android:text="Owned"
-            android:textSize="9sp"
-            android:textStyle="bold"
-            android:textColor="#FFFFFF"
-            android:background="?attr/pyluxAccentA30"
-            android:visibility="gone" />
+            android:visibility="gone">
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@drawable/bg_streamability_circle" />
+
+            <ImageView
+                android:id="@+id/streamabilityIcon"
+                android:layout_width="14dp"
+                android:layout_height="14dp"
+                android:layout_gravity="center"
+                android:contentDescription="Streamability status"
+                android:src="@drawable/ic_check_white" />
+
+        </FrameLayout>
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -71,28 +77,6 @@
             android:paddingEnd="8dp"
             android:paddingTop="8dp"
             android:paddingBottom="8dp">
-
-            <FrameLayout
-                android:id="@+id/streamabilityBadge"
-                android:layout_width="18dp"
-                android:layout_height="18dp"
-                android:layout_marginEnd="6dp"
-                android:visibility="gone">
-
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:background="@drawable/bg_streamability_circle" />
-
-                <ImageView
-                    android:id="@+id/streamabilityIcon"
-                    android:layout_width="11dp"
-                    android:layout_height="11dp"
-                    android:layout_gravity="center"
-                    android:contentDescription="Streamability status"
-                    android:src="@drawable/ic_check_white" />
-
-            </FrameLayout>
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/gameNameTextView"

--- a/android/app/src/test/java/com/metallic/chiaki/cloudplay/model/CloudGameFilteringTest.kt
+++ b/android/app/src/test/java/com/metallic/chiaki/cloudplay/model/CloudGameFilteringTest.kt
@@ -30,15 +30,15 @@ class CloudGameFilteringTest {
     }
 
     // Mirrors the sortState block in CloudPlayFragment.observeViewModel
-    private fun applySortState(games: List<CloudGame>, sortState: Int, section: String): List<CloudGame> =
+    private fun applySortState(
+        games: List<CloudGame>,
+        sortState: Int,
+        lastPlayedMs: Map<String, Long> = emptyMap()
+    ): List<CloudGame> =
         when (sortState) {
-            0 -> if (section == "pscloud")
-                games.sortedWith(compareByDescending { it.isOwned })
-            else
-                games
-            1 -> games.sortedBy { it.name.lowercase() }
-            2 -> games.sortedByDescending { it.name.lowercase() }
-            else -> games
+            1 -> games.sortedByDescending { it.name.lowercase() }
+            2 -> games.sortedByDescending { lastPlayedMs[it.productId] ?: 0L }
+            else -> games.sortedBy { it.name.lowercase() } // A->Z (default)
         }
 
     // --- Platform filtering ---
@@ -83,64 +83,75 @@ class CloudGameFilteringTest {
         assertTrue(filterBySection(emptyList(), "pscloud").isEmpty())
     }
 
-    // --- Sort: A→Z ---
+    // --- Sort: A→Z (default) ---
 
     @Test
-    fun `sort state 1 orders games A to Z`() {
+    fun `sort state 0 orders games A to Z`() {
         val games = listOf(
             CloudGame("C", "Zelda", ""),
             CloudGame("A", "Astro's Playroom", ""),
             CloudGame("B", "Batman", "")
         )
-        val sorted = applySortState(games, 1, "psnow_ps4")
+        val sorted = applySortState(games, 0)
         assertEquals(listOf("Astro's Playroom", "Batman", "Zelda"), sorted.map { it.name })
     }
 
     @Test
-    fun `sort state 1 is case-insensitive`() {
+    fun `sort state 0 is case-insensitive`() {
         val games = listOf(
             CloudGame("B", "zelda", ""),
             CloudGame("A", "Astro", "")
         )
-        val sorted = applySortState(games, 1, "psnow_ps4")
+        val sorted = applySortState(games, 0)
+        assertEquals("Astro", sorted.first().name)
+    }
+
+    @Test
+    fun `an unrecognised sort state falls back to A to Z`() {
+        val games = listOf(CloudGame("B", "Zelda", ""), CloudGame("A", "Astro", ""))
+        val sorted = applySortState(games, 99)
         assertEquals("Astro", sorted.first().name)
     }
 
     // --- Sort: Z→A ---
 
     @Test
-    fun `sort state 2 orders games Z to A`() {
+    fun `sort state 1 orders games Z to A`() {
         val games = listOf(
             CloudGame("C", "Zelda", ""),
             CloudGame("A", "Astro's Playroom", ""),
             CloudGame("B", "Batman", "")
         )
-        val sorted = applySortState(games, 2, "psnow_ps4")
+        val sorted = applySortState(games, 1)
         assertEquals(listOf("Zelda", "Batman", "Astro's Playroom"), sorted.map { it.name })
     }
 
-    // --- Sort: default (Library owned-first) ---
+    // --- Sort: Recently Played (works the same for Catalog and Library sections) ---
 
     @Test
-    fun `Library default sort places owned games before unowned`() {
+    fun `sort state 2 orders games by most recently played first`() {
         val games = listOf(
-            CloudGame("A", "Unowned Game", "", serviceType = "pscloud", isOwned = false),
-            CloudGame("B", "Owned Game",   "", serviceType = "pscloud", isOwned = true)
+            CloudGame("A", "Played Long Ago", "", platform = "ps3"),
+            CloudGame("B", "Played Most Recently", "", platform = "ps4"),
+            CloudGame("C", "Never Played", "", platform = "ps5", serviceType = "pscloud")
         )
-        val sorted = applySortState(games, 0, "pscloud")
-        assertEquals("Owned Game", sorted.first().name)
-        assertEquals("Unowned Game", sorted.last().name)
+        val lastPlayed = mapOf("A" to 1_000L, "B" to 5_000L) // "C" absent == never played
+        val sorted = applySortState(games, 2, lastPlayed)
+        assertEquals(
+            listOf("Played Most Recently", "Played Long Ago", "Never Played"),
+            sorted.map { it.name }
+        )
     }
 
     @Test
-    fun `Catalog default sort preserves original order`() {
+    fun `sort state 2 treats games with no recorded playtime as least recent`() {
         val games = listOf(
-            CloudGame("G3", "Gamma", ""),
-            CloudGame("G1", "Alpha", ""),
-            CloudGame("G2", "Beta", "")
+            CloudGame("A", "Has Playtime", ""),
+            CloudGame("B", "No Playtime", "")
         )
-        val sorted = applySortState(games, 0, "psnow_ps3")
-        assertEquals(listOf("Gamma", "Alpha", "Beta"), sorted.map { it.name })
+        val sorted = applySortState(games, 2, mapOf("A" to 42L))
+        assertEquals("Has Playtime", sorted.first().name)
+        assertEquals("No Playtime", sorted.last().name)
     }
 
     // --- Search logic (mirrors ViewModel.applySearchFilter) ---

--- a/android/app/src/test/java/com/metallic/chiaki/cloudplay/model/PlaytimeFormatterTest.kt
+++ b/android/app/src/test/java/com/metallic/chiaki/cloudplay/model/PlaytimeFormatterTest.kt
@@ -1,0 +1,59 @@
+package com.metallic.chiaki.cloudplay.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PlaytimeFormatterTest {
+
+    @Test
+    fun `total playtime of zero is not yet played`() {
+        assertEquals("Not yet played", PlaytimeFormatter.formatTotalPlaytime(0L))
+        assertEquals("Not yet played", PlaytimeFormatter.formatTotalPlaytime(-1L))
+    }
+
+    @Test
+    fun `total playtime under an hour shows minutes only`() {
+        assertEquals("5m", PlaytimeFormatter.formatTotalPlaytime(5 * 60_000L))
+    }
+
+    @Test
+    fun `total playtime under a day shows hours and minutes but no days`() {
+        val ms = (3 * 60 + 20) * 60_000L // 3h 20m
+        assertEquals("3h 20m", PlaytimeFormatter.formatTotalPlaytime(ms))
+    }
+
+    @Test
+    fun `total playtime over a day shows days hours and minutes`() {
+        val ms = (26 * 60 + 15) * 60_000L // 1d 2h 15m
+        assertEquals("1d 2h 15m", PlaytimeFormatter.formatTotalPlaytime(ms))
+    }
+
+    @Test
+    fun `total playtime with whole days and no leftover hours still prints 0h`() {
+        val ms = 48 * 60 * 60_000L // exactly 2 days
+        assertEquals("2d 0h 0m", PlaytimeFormatter.formatTotalPlaytime(ms))
+    }
+
+    @Test
+    fun `session duration of zero is not yet played`() {
+        assertEquals("Not yet played", PlaytimeFormatter.formatSessionDuration(0L))
+        assertEquals("Not yet played", PlaytimeFormatter.formatSessionDuration(-5L))
+    }
+
+    @Test
+    fun `session duration under an hour omits the hours component`() {
+        assertEquals("45m", PlaytimeFormatter.formatSessionDuration(45 * 60_000L))
+    }
+
+    @Test
+    fun `session duration over an hour shows hours and minutes`() {
+        val ms = (2 * 60 + 5) * 60_000L // 2h 5m
+        assertEquals("2h 5m", PlaytimeFormatter.formatSessionDuration(ms))
+    }
+
+    @Test
+    fun `session duration rounds down partial minutes`() {
+        // 90 seconds -> 1 minute (integer division truncates, matches total playtime rounding)
+        assertEquals("1m", PlaytimeFormatter.formatSessionDuration(90_000L))
+    }
+}


### PR DESCRIPTION
Tracks total playtime, last-played timestamp, and longest session per game across PS3 Catalog, PS4 Catalog, and PS5 Library, hooked into the existing stream-time-flush logic in StreamActivity. Adds a long-press "Playtime" menu item (also reachable via Square on a controller) showing these stats, and a "Recently Played" sort option available on all three tabs.

Also replaces the PS5 Library's static "Owned" badge with the streamability check/cross/question-mark badge in the same top-right corner, and drops the redundant "Owned First"/"Recent" default sort in favour of "Name: A → Z" everywhere.