### PR TITLE
Add in-stream trophy unlock popup

### DIFF
--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -97,9 +97,8 @@ jobs:
             ## CloudPad Beta Release ${{ env.VERSION }}
 
             ### Updates
-            - Fixed PS4 and PS5 trophy support for games where games are available for both platforms.
-            - Fixed trophy support for games that have roman numerals in the title.
-            - If you aren't seeing trophies to begin with, you will need to start the game, wait a couple of minutes and then refresh the trophy list. Then they will appear. 
+            - Added an in-stream popup that appears in the top-left corner when you unlock a new trophy, showing a themed "Trophy unlocked!" header, the trophy's image, name, description and Bronze/Silver/Gold/Platinum badge for 10 seconds. Only fires for trophies earned during the current session, for the game you're actually playing.
+            - Fixed the Trophies feature re-authenticating with PSN from scratch on every check instead of reusing its existing login for up to an hour, which was wasting network calls in the background during every stream.
 
             ### APK
             Attached release asset:

--- a/android/app/src/main/java/com/metallic/chiaki/common/Preferences.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/common/Preferences.kt
@@ -275,8 +275,14 @@ class Preferences(context: Context)
 		get() = sharedPreferences.getLong(PSN_TROPHY_AUTH_TOKEN_EXPIRY_KEY, 0L)
 		set(value) { sharedPreferences.edit().putLong(PSN_TROPHY_AUTH_TOKEN_EXPIRY_KEY, value).apply() }
 
+	// Only the access token is required here — Sony's response for this client/scope doesn't
+	// always include a refresh_token, which used to make this permanently false and force a
+	// full NPSSO->code->token re-exchange on every single call (confirmed live: every ~30s poll
+	// from TrophyUnlockWatcher was re-authenticating from scratch instead of reusing the still-
+	// valid cached access token). getValidToken()/refreshToken() already fall back to a fresh
+	// exchange once the access token actually expires and no refresh token is available.
 	val hasPsnTrophyTokens: Boolean
-		get() = psnTrophyAuthToken.isNotEmpty() && psnTrophyRefreshToken.isNotEmpty()
+		get() = psnTrophyAuthToken.isNotEmpty()
 
 	val isPsnTrophyTokenExpired: Boolean
 		get()

--- a/android/app/src/main/java/com/metallic/chiaki/stream/StreamActivity.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/stream/StreamActivity.kt
@@ -20,6 +20,7 @@ import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.*
+import androidx.lifecycle.lifecycleScope
 
 import com.pylux.stream.R
 import com.metallic.chiaki.common.Preferences
@@ -34,6 +35,8 @@ import com.metallic.chiaki.session.StreamStateIdle
 import com.metallic.chiaki.session.StreamStateLoginPinRequest
 import com.metallic.chiaki.session.StreamStateQuit
 import com.metallic.chiaki.session.StreamState
+import com.metallic.chiaki.trophy.TrophyRepository
+import com.metallic.chiaki.trophy.TrophyUnlockWatcher
 import com.metallic.chiaki.touchcontrols.DefaultTouchControlsFragment
 import com.metallic.chiaki.touchcontrols.TouchControlsFragment
 import com.metallic.chiaki.touchcontrols.TouchpadOnlyFragment
@@ -56,6 +59,11 @@ class StreamActivity : AppCompatActivity(), View.OnSystemUiVisibilityChangeListe
 	private lateinit var viewModel: StreamViewModel
 	private lateinit var binding: ActivityStreamBinding
 	private lateinit var quickSettingsPanel: QuickSettingsPanel
+	private lateinit var trophyUnlockPopupPresenter: TrophyUnlockPopupPresenter
+
+	/** Only created for cloud sessions (Catalog/Library), which are the only ones with a known
+	 *  game name/platform to match trophies against — null for Remote Play. */
+	private var trophyUnlockWatcher: TrophyUnlockWatcher? = null
 
 	/** Result callback for the most recent [micPermissionLauncher] request, invoked with the
 	 *  grant result then cleared. Must be registered before STARTED, hence a class field. */
@@ -110,6 +118,26 @@ class StreamActivity : AppCompatActivity(), View.OnSystemUiVisibilityChangeListe
 		binding = ActivityStreamBinding.inflate(layoutInflater)
 		setContentView(binding.root)
 		window.decorView.setOnSystemUiVisibilityChangeListener(this)
+
+		trophyUnlockPopupPresenter = TrophyUnlockPopupPresenter(
+			container = binding.trophyUnlockPopup,
+			iconView = binding.trophyUnlockPopupIcon,
+			textView = binding.trophyUnlockPopupText,
+			detailView = binding.trophyUnlockPopupDetail,
+			badgeView = binding.trophyUnlockPopupBadge
+		)
+
+		val cloudGameName = connectInfo.cloudGameName
+		val cloudGamePlatform = connectInfo.cloudGamePlatform
+		if (!cloudGameName.isNullOrBlank() && !cloudGamePlatform.isNullOrBlank())
+		{
+			trophyUnlockWatcher = TrophyUnlockWatcher(
+				trophyRepository = TrophyRepository(viewModel.preferences),
+				gameName = cloudGameName,
+				platform = cloudGamePlatform,
+				onTrophiesUnlocked = { trophies -> trophyUnlockPopupPresenter.enqueue(trophies) }
+			)
+		}
 
 		// Quick Settings panel — replaces the old bottom overlay bar entirely. Disconnect,
 		// Performance Overlay, On-Screen Controls, Touchpad Only and Window Size all live
@@ -371,6 +399,9 @@ class StreamActivity : AppCompatActivity(), View.OnSystemUiVisibilityChangeListe
 
 	private fun flushStreamTimeSegment()
 	{
+		trophyUnlockWatcher?.stop()
+		trophyUnlockPopupPresenter.cancel()
+
 		if (connectedAtElapsedRealtime == 0L) return
 		val delta = SystemClock.elapsedRealtime() - connectedAtElapsedRealtime
 		if (delta > 0L)
@@ -398,6 +429,7 @@ class StreamActivity : AppCompatActivity(), View.OnSystemUiVisibilityChangeListe
 					connectedAtElapsedRealtime = SystemClock.elapsedRealtime()
 					connectedAtWallClockMs = System.currentTimeMillis()
 				}
+				trophyUnlockWatcher?.start(lifecycleScope)
 			}
 
 			StreamStateConnecting ->

--- a/android/app/src/main/java/com/metallic/chiaki/stream/TrophyUnlockPopupPresenter.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/stream/TrophyUnlockPopupPresenter.kt
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
+
+package com.metallic.chiaki.stream
+
+import android.os.Handler
+import android.os.Looper
+import android.view.View
+import android.widget.ImageView
+import android.widget.TextView
+import coil.load
+import com.metallic.chiaki.trophy.model.Trophy
+import com.metallic.chiaki.trophy.model.TrophyType
+import com.pylux.stream.R
+
+/**
+ * Shows the in-stream trophy-unlock popup one trophy at a time, queueing any additional
+ * trophies detected while one is already on screen. Each popup stays up for
+ * [DISPLAY_DURATION_MS] then either advances to the next queued trophy or hides.
+ */
+class TrophyUnlockPopupPresenter(
+	private val container: View,
+	private val iconView: ImageView,
+	private val textView: TextView,
+	private val detailView: TextView,
+	private val badgeView: TextView
+)
+{
+	companion object
+	{
+		private const val DISPLAY_DURATION_MS = 10_000L
+	}
+
+	private val handler = Handler(Looper.getMainLooper())
+	private val queue = ArrayDeque<Trophy>()
+	private val hideRunnable = Runnable { showNextOrHide() }
+
+	fun enqueue(trophies: List<Trophy>)
+	{
+		val wasIdle = queue.isEmpty() && container.visibility != View.VISIBLE
+		queue.addAll(trophies)
+		if (wasIdle) showNextOrHide()
+	}
+
+	private fun showNextOrHide()
+	{
+		handler.removeCallbacks(hideRunnable)
+		val next = queue.removeFirstOrNull()
+		if (next == null)
+		{
+			container.visibility = View.GONE
+			return
+		}
+
+		textView.text = next.name
+		detailView.text = next.detail
+		if (next.iconUrl.isNotEmpty())
+			iconView.load(next.iconUrl) { crossfade(true) }
+		else
+			iconView.setImageResource(android.R.drawable.ic_menu_gallery)
+
+		badgeView.text = next.type.name
+		badgeView.setBackgroundResource(
+			when (next.type)
+			{
+				TrophyType.BRONZE -> R.drawable.bg_trophy_bronze
+				TrophyType.SILVER -> R.drawable.bg_trophy_silver
+				TrophyType.GOLD -> R.drawable.bg_trophy_gold
+				TrophyType.PLATINUM -> R.drawable.bg_trophy_platinum
+			}
+		)
+
+		container.visibility = View.VISIBLE
+		handler.postDelayed(hideRunnable, DISPLAY_DURATION_MS)
+	}
+
+	/** Stops any pending auto-advance/hide and clears the queue — used when the stream
+	 *  disconnects so a delayed callback doesn't fire against a torn-down session. */
+	fun cancel()
+	{
+		handler.removeCallbacks(hideRunnable)
+		queue.clear()
+		container.visibility = View.GONE
+	}
+}

--- a/android/app/src/main/java/com/metallic/chiaki/trophy/TrophyUnlockDiff.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/trophy/TrophyUnlockDiff.kt
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
+
+package com.metallic.chiaki.trophy
+
+import com.metallic.chiaki.trophy.model.Trophy
+
+/**
+ * Pure diffing logic behind the in-stream trophy-unlock popup: compares a freshly fetched
+ * trophy list's earned trophies against the set already known from the previous poll, and
+ * reports only the ones that newly transitioned to earned. Pulled out from [TrophyUnlockWatcher]
+ * so the "what counts as newly unlocked" rule can be unit tested without any network dependency.
+ */
+object TrophyUnlockDiff
+{
+	/**
+	 * [previousEarnedIds] is null on the very first poll of a session — in that case every
+	 * already-earned trophy silently becomes the baseline (the user didn't earn these during
+	 * this stream, so none are reported), and only trophies earned since baseline are ever
+	 * returned by later calls. Returns the updated baseline to keep, plus the newly-earned
+	 * trophies to notify.
+	 */
+	fun diff(previousEarnedIds: Set<Int>?, trophies: List<Trophy>): Pair<Set<Int>, List<Trophy>>
+	{
+		val earnedNow = trophies.filter { it.earned }.map { it.trophyId }.toSet()
+
+		if (previousEarnedIds == null) return earnedNow to emptyList()
+
+		val newlyEarnedIds = earnedNow - previousEarnedIds
+		if (newlyEarnedIds.isEmpty()) return previousEarnedIds to emptyList()
+
+		val newlyEarned = trophies.filter { it.trophyId in newlyEarnedIds }
+		return earnedNow to newlyEarned
+	}
+}

--- a/android/app/src/main/java/com/metallic/chiaki/trophy/TrophyUnlockWatcher.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/trophy/TrophyUnlockWatcher.kt
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
+
+package com.metallic.chiaki.trophy
+
+import android.util.Log
+import com.metallic.chiaki.trophy.model.Trophy
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+/**
+ * Polls the currently-streamed game's trophy list at a fixed interval for the lifetime of a
+ * stream session, so [onTrophiesUnlocked] can be used to show an unlock popup the moment a new
+ * trophy appears. Only ever reports trophies that transition to earned after [start] is called
+ * (see [TrophyUnlockDiff]) — trophies the account already had are never reported.
+ *
+ * [forceRefresh] is deliberately left off the poll: TrophyRepository always fetches this game's
+ * trophy detail fresh regardless, so the only thing forceRefresh would buy here is bypassing the
+ * account-wide trophy titles cache, which isn't needed for an already-matched game mid-session.
+ */
+class TrophyUnlockWatcher(
+	private val trophyRepository: TrophyRepository,
+	private val gameName: String,
+	private val platform: String,
+	private val onTrophiesUnlocked: (List<Trophy>) -> Unit
+)
+{
+	companion object
+	{
+		private const val TAG = "TrophyUnlockWatcher"
+		private const val POLL_INTERVAL_MS = 30_000L
+	}
+
+	private var job: Job? = null
+	private var baselineEarnedIds: Set<Int>? = null
+
+	fun start(scope: CoroutineScope)
+	{
+		if (job?.isActive == true) return
+		Log.i(TAG, "Started polling trophies for \"$gameName\" ($platform) every ${POLL_INTERVAL_MS}ms")
+		job = scope.launch {
+			while (isActive)
+			{
+				poll()
+				delay(POLL_INTERVAL_MS)
+			}
+		}
+	}
+
+	fun stop()
+	{
+		if (job != null) Log.i(TAG, "Stopped polling trophies for \"$gameName\" ($platform)")
+		job?.cancel()
+		job = null
+	}
+
+	private suspend fun poll()
+	{
+		val result = trophyRepository.fetchTrophiesForGame(gameName, platform, forceRefresh = false)
+		val detail = (result as? TrophyResult.Success)?.detail
+		if (detail == null)
+		{
+			Log.i(TAG, "Poll skipped: no trophy detail available yet for \"$gameName\" ($result)")
+			return
+		}
+
+		val (updatedBaseline, newlyUnlocked) = TrophyUnlockDiff.diff(baselineEarnedIds, detail.trophies)
+		val isFirstPoll = baselineEarnedIds == null
+		baselineEarnedIds = updatedBaseline
+
+		if (isFirstPoll)
+		{
+			Log.i(TAG, "Baseline established: ${updatedBaseline.size} already-earned trophy/trophies for \"$gameName\"")
+		}
+		else if (newlyUnlocked.isNotEmpty())
+		{
+			Log.i(TAG, "Newly unlocked: ${newlyUnlocked.joinToString { it.name }}")
+			onTrophiesUnlocked(newlyUnlocked)
+		}
+	}
+}

--- a/android/app/src/main/res/drawable/bg_trophy_unlock_popup.xml
+++ b/android/app/src/main/res/drawable/bg_trophy_unlock_popup.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/disclaimer_box_background"/>
+    <corners android:radius="10dp"/>
+    <stroke android:width="2dp" android:color="?attr/pyluxAccent"/>
+</shape>

--- a/android/app/src/main/res/layout/activity_stream.xml
+++ b/android/app/src/main/res/layout/activity_stream.xml
@@ -32,7 +32,87 @@
         android:layout_height="wrap_content"
         android:layout_gravity="top|start"
         android:layout_margin="8dp"
-        android:visibility="gone"/>        
+        android:visibility="gone"/>
+
+    <!-- Trophy unlock popup: shown by TrophyUnlockPopupPresenter for up to 10s per trophy.
+         Positioned below the (usually-off) Performance Overlay to avoid the two overlapping. -->
+    <LinearLayout
+        android:id="@+id/trophyUnlockPopup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top|start"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="88dp"
+        android:orientation="vertical"
+        android:paddingHorizontal="12dp"
+        android:paddingVertical="10dp"
+        android:background="@drawable/bg_trophy_unlock_popup"
+        android:visibility="gone"
+        android:elevation="8dp">
+
+        <TextView
+            android:id="@+id/trophyUnlockPopupHeader"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="6dp"
+            android:text="@string/trophy_unlock_popup_header"
+            android:textColor="?attr/pyluxAccent"
+            android:textSize="12sp"
+            android:textStyle="bold"/>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <ImageView
+                android:id="@+id/trophyUnlockPopupIcon"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:scaleType="centerCrop"/>
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:layout_marginEnd="10dp"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/trophyUnlockPopupText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:maxWidth="200dp"
+                    android:textColor="@android:color/white"
+                    android:textSize="14sp"
+                    android:textStyle="bold"/>
+
+                <TextView
+                    android:id="@+id/trophyUnlockPopupDetail"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="2dp"
+                    android:maxWidth="200dp"
+                    android:maxLines="2"
+                    android:ellipsize="end"
+                    android:textColor="#B3B3B3"
+                    android:textSize="12sp"/>
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/trophyUnlockPopupBadge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingStart="8dp"
+                android:paddingEnd="8dp"
+                android:paddingTop="3dp"
+                android:paddingBottom="3dp"
+                android:textColor="#000000"
+                android:textSize="9sp"
+                android:textStyle="bold"/>
+        </LinearLayout>
+    </LinearLayout>
 
     <fragment
         android:id="@+id/controlsFragment"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -165,6 +165,7 @@
     <string name="quick_settings_trophies_header_label">Refresh Trophy List</string>
     <string name="quick_settings_trophies_refresh">Refresh trophies</string>
     <string name="quick_settings_trophies_empty">No trophy data found for this game</string>
+    <string name="trophy_unlock_popup_header">Trophy unlocked!</string>
     <string name="alert_message_delete_registered_host">Are you sure you want to delete the registered console %s with ID %s?</string>
     <string name="alert_message_delete_manual_host">Are you sure you want to delete the console entry for %s?</string>
     <string name="action_keep">Keep</string>

--- a/android/app/src/test/java/com/metallic/chiaki/trophy/TrophyUnlockDiffTest.kt
+++ b/android/app/src/test/java/com/metallic/chiaki/trophy/TrophyUnlockDiffTest.kt
@@ -1,0 +1,65 @@
+package com.metallic.chiaki.trophy
+
+import com.metallic.chiaki.trophy.model.Trophy
+import com.metallic.chiaki.trophy.model.TrophyType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TrophyUnlockDiffTest {
+
+    private fun trophy(id: Int, name: String, earned: Boolean) = Trophy(
+        trophyId = id,
+        groupId = "default",
+        type = TrophyType.BRONZE,
+        name = name,
+        detail = "",
+        iconUrl = "",
+        hidden = false,
+        earned = earned,
+        earnedDateTimeMs = if (earned) 1_000L else null
+    )
+
+    @Test
+    fun `first poll establishes a silent baseline and reports nothing`() {
+        val trophies = listOf(trophy(1, "Already Earned", earned = true), trophy(2, "Locked", earned = false))
+        val (baseline, unlocked) = TrophyUnlockDiff.diff(null, trophies)
+        assertEquals(setOf(1), baseline)
+        assertTrue(unlocked.isEmpty())
+    }
+
+    @Test
+    fun `a trophy earned since the baseline is reported as newly unlocked`() {
+        val baseline = setOf(1)
+        val trophies = listOf(trophy(1, "Already Earned", earned = true), trophy(2, "Just Unlocked", earned = true))
+        val (updatedBaseline, unlocked) = TrophyUnlockDiff.diff(baseline, trophies)
+        assertEquals(setOf(1, 2), updatedBaseline)
+        assertEquals(listOf("Just Unlocked"), unlocked.map { it.name })
+    }
+
+    @Test
+    fun `no newly earned trophies reports an empty list and keeps the same baseline`() {
+        val baseline = setOf(1)
+        val trophies = listOf(trophy(1, "Already Earned", earned = true), trophy(2, "Still Locked", earned = false))
+        val (updatedBaseline, unlocked) = TrophyUnlockDiff.diff(baseline, trophies)
+        assertEquals(baseline, updatedBaseline)
+        assertTrue(unlocked.isEmpty())
+    }
+
+    @Test
+    fun `multiple trophies earned in the same poll are all reported`() {
+        val baseline = emptySet<Int>()
+        val trophies = listOf(trophy(1, "First", earned = true), trophy(2, "Second", earned = true))
+        val (updatedBaseline, unlocked) = TrophyUnlockDiff.diff(baseline, trophies)
+        assertEquals(setOf(1, 2), updatedBaseline)
+        assertEquals(setOf("First", "Second"), unlocked.map { it.name }.toSet())
+    }
+
+    @Test
+    fun `a previously unlocked trophy is never reported again on a later poll`() {
+        val baseline = setOf(1, 2)
+        val trophies = listOf(trophy(1, "Already Earned", earned = true), trophy(2, "Reported Last Time", earned = true))
+        val (_, unlocked) = TrophyUnlockDiff.diff(baseline, trophies)
+        assertTrue(unlocked.isEmpty())
+    }
+}


### PR DESCRIPTION
Shows a themed "Trophy unlocked!" popup in the top-left corner of the stream for 10 seconds when a new trophy is earned during the current session, with the trophy's icon, name, description and Bronze/Silver/ Gold/Platinum badge. TrophyUnlockWatcher polls the streamed game's trophy list every 30s and diffs against a session baseline so only newly-earned trophies (not ones already unlocked before the stream started) ever trigger a popup.

Also fixes hasPsnTrophyTokens requiring a refresh token that Sony's API doesn't always return for this scope, which was forcing a full NPSSO re-authentication on every single poll instead of reusing the still-valid cached access token.