### PR TITLE
Update no-trophy-data message with sync guidance and issue link

### DIFF
--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -97,12 +97,7 @@ jobs:
             ## CloudPad Beta Release ${{ env.VERSION }}
 
             ### Updates
-            - Added full controller (D-pad/Cross/Circle) navigation to the in-stream Quick Settings panel: press a tab icon to drill into its content, Circle steps back out to the tab rail, and every switch/dropdown/seek bar/button now shows a clear focus highlight.
-            - Added a "Current game" header (cover art + title) to the Quick Settings panel for PS3/PS4/PS5 cloud streaming, and hid the Trophies tab for Remote Play sessions, which have no catalog game to show trophies for.
-            - Added a completion summary (percentage + trophy badge counts) to the Quick Settings panel's Trophies tab, matching the full Trophies screen's styling.
-            - Fixed the Trophies list showing a duplicate "Trophies" header every time a game had more than one unnamed trophy group, instead of just once at the top.
-            - Fixed the bitrate seek bar in Quick Settings stepping by 10 instead of 1 when adjusted with a D-pad.
-            - Fixed D-pad focus in the Quick Settings panel being able to reach the disconnect/close buttons from inside a tab's content, and fixed holding D-pad down in the Trophies tab losing focus out of the list entirely.
+            - Updated the "no trophy data" message (Quick Settings Trophies tab and full Trophies screen) to explain that the game needs to be launched and synced, that syncing can take 5-10 minutes, and to raise a GitHub issue if data is still missing after that.
 
             ### APK
             Attached release asset:

--- a/android/app/src/main/java/com/metallic/chiaki/stream/QuickSettingsPanel.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/stream/QuickSettingsPanel.kt
@@ -458,7 +458,7 @@ class QuickSettingsPanel(
 					val items = buildTrophyListItems(result.detail)
 					if(items.isEmpty())
 					{
-						showTrophiesEmptyState(activity.getString(R.string.quick_settings_trophies_empty))
+						showTrophiesEmptyState(activity.getString(R.string.quick_settings_trophies_empty, gameName))
 					}
 					else
 					{
@@ -467,7 +467,7 @@ class QuickSettingsPanel(
 						showTrophiesSummary(result.detail.summary)
 					}
 				}
-				is TrophyResult.NoMatchFound -> showTrophiesEmptyState(activity.getString(R.string.quick_settings_trophies_empty))
+				is TrophyResult.NoMatchFound -> showTrophiesEmptyState(activity.getString(R.string.quick_settings_trophies_empty, gameName))
 				is TrophyResult.Error -> showTrophiesEmptyState(result.message)
 			}
 		}

--- a/android/app/src/main/java/com/metallic/chiaki/trophy/TrophiesActivity.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/trophy/TrophiesActivity.kt
@@ -15,6 +15,7 @@ import coil.load
 import com.metallic.chiaki.cloudplay.model.CloudGame
 import com.metallic.chiaki.common.Preferences
 import com.metallic.chiaki.trophy.model.TrophyTitleDetail
+import com.pylux.stream.R
 import com.pylux.stream.databinding.ActivityTrophiesBinding
 import kotlinx.coroutines.launch
 
@@ -96,14 +97,14 @@ class TrophiesActivity : AppCompatActivity()
 		lifecycleScope.launch {
 			when (val result = repository.fetchTrophiesForGame(gameName, platform))
 			{
-				is TrophyResult.Success -> showTrophies(result.detail)
-				is TrophyResult.NoMatchFound -> showEmptyState("No trophy data found for this game")
+				is TrophyResult.Success -> showTrophies(result.detail, gameName)
+				is TrophyResult.NoMatchFound -> showEmptyState(getString(R.string.quick_settings_trophies_empty, gameName))
 				is TrophyResult.Error -> showEmptyState(result.message)
 			}
 		}
 	}
 
-	private fun showTrophies(detail: TrophyTitleDetail)
+	private fun showTrophies(detail: TrophyTitleDetail, gameName: String)
 	{
 		binding.trophyProgressBar.visibility = View.GONE
 
@@ -118,7 +119,7 @@ class TrophiesActivity : AppCompatActivity()
 
 		if (items.isEmpty())
 		{
-			showEmptyState("No trophy data found for this game")
+			showEmptyState(getString(R.string.quick_settings_trophies_empty, gameName))
 			return
 		}
 

--- a/android/app/src/main/res/layout/activity_trophies.xml
+++ b/android/app/src/main/res/layout/activity_trophies.xml
@@ -114,11 +114,11 @@
 
     <TextView
         android:id="@+id/trophyEmptyStateText"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
         android:gravity="center"
-        android:text="No trophy data found for this game"
+        android:text="@string/quick_settings_trophies_empty"
         android:textColor="#B3B3B3"
         android:textSize="14sp"
         android:visibility="gone"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -165,7 +165,7 @@
     <string name="quick_settings_trophies_tab_description">Trophies</string>
     <string name="quick_settings_trophies_header_label">Refresh Trophy List</string>
     <string name="quick_settings_trophies_refresh">Refresh trophies</string>
-    <string name="quick_settings_trophies_empty">No trophy data found for this game</string>
+    <string name="quick_settings_trophies_empty">No trophy data could be retrieved for %1$s, please launch the game and allow the trophy to be synched.\n\nThis can take around 5-10 minutes during a session. Then you can refresh the trophy list and the trophy data should appear.\n\nIf the trophy data is still missing, please raise an issue on the CloudPad github repository to be looked into</string>
     <string name="trophy_unlock_popup_header">Trophy unlocked!</string>
     <string name="alert_message_delete_registered_host">Are you sure you want to delete the registered console %s with ID %s?</string>
     <string name="alert_message_delete_manual_host">Are you sure you want to delete the console entry for %s?</string>


### PR DESCRIPTION
Explains that the game needs to be launched and synced (5-10 minutes), to refresh afterward, and to raise a GitHub issue if data is still missing.