### PR TITLE
Show trophy detail popup on tap instead of truncating long names

### DIFF
--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -101,11 +101,7 @@ jobs:
             ## CloudPad Beta Release ${{ env.VERSION }}
 
             ### Updates
-            - Added a Trophy Compare feature: tap the trophy icon on a friend's row (main menu or Quick Settings) to see a side-by-side comparison of account level, total trophies, platinum/gold/silver/bronze counts, and shared games with progress bars.
-            - Fixed several D-pad/controller focus bugs: overlapping focus rectangles on friend rows, doubled focus highlights on Trophies/Trophy Compare/Friends lists, and list scrolling occasionally getting "stuck" for a few button presses.
-            - Fixed shared games in Trophy Compare only showing one entry, and your own profile picture not loading, when there were more games or the picture failed to fetch correctly.
-            - Restyled every pop-up dialog across the app to a consistent rounded box with a grey background and theme-coloured border.
-            - Redesigned the Trophy Compare header for landscape use, with clearer "Level:" and "Total Trophies:" labels that resize to fit both the full-screen and Quick Settings layouts without getting cut off.
+            - Tapping a trophy in the Trophies list (Quick Settings or the full-screen Trophies screen) now opens a detail pop-up with the full trophy name, description, icon, and earned date, so long trophy names/descriptions are no longer cut off with "...".
 
             ### APK
             Attached release asset:

--- a/android/app/src/main/java/com/metallic/chiaki/stream/QuickSettingsPanel.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/stream/QuickSettingsPanel.kt
@@ -57,6 +57,7 @@ import com.metallic.chiaki.trophy.TrophyAdapter
 import com.metallic.chiaki.trophy.TrophyRepository
 import com.metallic.chiaki.trophy.TrophyResult
 import com.metallic.chiaki.trophy.buildTrophyListItems
+import com.metallic.chiaki.trophy.showTrophyDetailDialog
 import com.metallic.chiaki.trophy.model.TrophyTitleSummary
 import com.pylux.stream.R
 import com.pylux.stream.databinding.ItemQuickSettingsDropdownBinding
@@ -189,7 +190,7 @@ class QuickSettingsPanel(
 	private val sessionType: StreamSessionType = viewModel.connectInfo.sessionType
 
 	private val trophyRepository = TrophyRepository(preferences)
-	private val trophyAdapter = TrophyAdapter()
+	private val trophyAdapter = TrophyAdapter(onTrophyClick = { trophy -> showTrophyDetailDialog(activity, trophy) })
 	private var trophiesLoadedOnce = false
 
 	private val friendsRepository = FriendsRepository(preferences)

--- a/android/app/src/main/java/com/metallic/chiaki/trophy/TrophiesActivity.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/trophy/TrophiesActivity.kt
@@ -40,7 +40,7 @@ class TrophiesActivity : AppCompatActivity()
 
 	private lateinit var binding: ActivityTrophiesBinding
 	private lateinit var repository: TrophyRepository
-	private val adapter = TrophyAdapter()
+	private val adapter = TrophyAdapter(onTrophyClick = { trophy -> showTrophyDetailDialog(this, trophy) })
 
 	override fun onCreate(savedInstanceState: Bundle?)
 	{

--- a/android/app/src/main/java/com/metallic/chiaki/trophy/TrophyAdapter.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/trophy/TrophyAdapter.kt
@@ -2,13 +2,17 @@
 
 package com.metallic.chiaki.trophy
 
+import android.content.Context
 import android.graphics.drawable.GradientDrawable
 import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import coil.load
+import com.metallic.chiaki.common.ext.alertDialogBuilder
 import com.metallic.chiaki.common.ext.disableDefaultFocusHighlight
 import com.metallic.chiaki.trophy.model.Trophy
 import com.metallic.chiaki.trophy.model.TrophyTitleDetail
@@ -58,7 +62,67 @@ fun buildTrophyListItems(detail: TrophyTitleDetail): List<TrophyListItem>
 	return items
 }
 
-class TrophyAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>()
+/** Shown when a trophy row is tapped in either [TrophiesActivity] or [QuickSettingsPanel]'s
+ *  Trophies tab — the row itself truncates long names/descriptions to fit, this shows them in
+ *  full, styled the same as the app's other popups (e.g. CloudPlayFragment's playtime dialog). */
+fun showTrophyDetailDialog(context: Context, trophy: Trophy)
+{
+	val isHiddenLocked = trophy.hidden && !trophy.earned
+	val view = LayoutInflater.from(context).inflate(R.layout.dialog_trophy_detail, null)
+
+	view.findViewById<TextView>(R.id.trophyDetailName).text =
+		if (isHiddenLocked) "Hidden Trophy" else trophy.name
+
+	view.findViewById<TextView>(R.id.trophyDetailDescription).text = if (isHiddenLocked)
+		"Complete this trophy to reveal its details"
+	else
+		trophy.detail
+
+	val typeBadge = view.findViewById<TextView>(R.id.trophyDetailTypeBadge)
+	typeBadge.text = trophy.type.name
+	typeBadge.setBackgroundResource(
+		when (trophy.type)
+		{
+			TrophyType.BRONZE -> R.drawable.bg_trophy_bronze
+			TrophyType.SILVER -> R.drawable.bg_trophy_silver
+			TrophyType.GOLD -> R.drawable.bg_trophy_gold
+			TrophyType.PLATINUM -> R.drawable.bg_trophy_platinum
+		}
+	)
+
+	view.findViewById<View>(R.id.trophyDetailLockBadge).visibility =
+		if (trophy.earned) View.GONE else View.VISIBLE
+
+	val earnedDateText = view.findViewById<TextView>(R.id.trophyDetailEarnedDate)
+	if (trophy.earned && trophy.earnedDateTimeMs != null)
+	{
+		earnedDateText.visibility = View.VISIBLE
+		val format = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT)
+		earnedDateText.text = "Earned ${format.format(Date(trophy.earnedDateTimeMs))}"
+	}
+	else
+	{
+		earnedDateText.visibility = View.GONE
+	}
+
+	val iconUrl = if (isHiddenLocked) "" else trophy.iconUrl
+	val iconView = view.findViewById<ImageView>(R.id.trophyDetailIcon)
+	if (iconUrl.isNotEmpty())
+	{
+		iconView.load(iconUrl) { crossfade(true) }
+	}
+	else
+	{
+		iconView.setImageResource(android.R.drawable.ic_menu_gallery)
+	}
+
+	context.alertDialogBuilder()
+		.setView(view)
+		.setPositiveButton("Close", null)
+		.show()
+}
+
+class TrophyAdapter(private val onTrophyClick: (Trophy) -> Unit = {}) : RecyclerView.Adapter<RecyclerView.ViewHolder>()
 {
 	companion object
 	{
@@ -88,6 +152,7 @@ class TrophyAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>()
 			itemView.isFocusable = true
 			itemView.isFocusableInTouchMode = true
 			itemView.disableDefaultFocusHighlight()
+			itemView.setOnClickListener { items()?.let { onTrophyClick(it) } }
 
 			val tv = TypedValue()
 			itemView.context.theme.resolveAttribute(R.attr.pyluxAccent, tv, true)
@@ -126,8 +191,13 @@ class TrophyAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>()
 
 	class TrophyViewHolder(private val binding: ItemTrophyBinding) : RecyclerView.ViewHolder(binding.root)
 	{
+		private var trophy: Trophy? = null
+		fun items(): Trophy? = trophy
+
 		fun bind(trophy: Trophy)
 		{
+			this.trophy = trophy
+
 			val isHiddenLocked = trophy.hidden && !trophy.earned
 
 			binding.trophyItemName.text = if (isHiddenLocked) "Hidden Trophy" else trophy.name

--- a/android/app/src/main/res/layout/dialog_trophy_detail.xml
+++ b/android/app/src/main/res/layout/dialog_trophy_detail.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- No background here — the theme-coloured border is applied to the dialog window itself
+     (see TrophyAdapter.showTrophyDetailDialog), matching dialog_playtime's convention. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="20dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <FrameLayout
+            android:layout_width="64dp"
+            android:layout_height="64dp">
+
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:cardCornerRadius="8dp"
+                app:cardElevation="0dp">
+
+                <ImageView
+                    android:id="@+id/trophyDetailIcon"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:scaleType="centerCrop"
+                    android:contentDescription="@null" />
+
+            </com.google.android.material.card.MaterialCardView>
+
+            <FrameLayout
+                android:id="@+id/trophyDetailLockBadge"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_gravity="bottom|end"
+                android:background="@drawable/bg_trophy_lock_circle"
+                android:visibility="gone">
+
+                <ImageView
+                    android:layout_width="14dp"
+                    android:layout_height="14dp"
+                    android:layout_gravity="center"
+                    android:src="@drawable/ic_lock_white"
+                    android:contentDescription="@null" />
+
+            </FrameLayout>
+
+        </FrameLayout>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginStart="14dp"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/trophyDetailName"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textColor="?attr/pyluxAccent"
+                android:textSize="18sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/trophyDetailTypeBadge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:paddingStart="8dp"
+                android:paddingEnd="8dp"
+                android:paddingTop="3dp"
+                android:paddingBottom="3dp"
+                android:textColor="#000000"
+                android:textSize="10sp"
+                android:textStyle="bold" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginBottom="16dp"
+        android:background="?attr/pyluxAccent"
+        android:alpha="0.3" />
+
+    <TextView
+        android:id="@+id/trophyDetailDescription"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textColor="@android:color/white"
+        android:textSize="14sp" />
+
+    <TextView
+        android:id="@+id/trophyDetailEarnedDate"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:textColor="?attr/pyluxAccent"
+        android:textSize="12sp"
+        android:visibility="gone" />
+
+</LinearLayout>


### PR DESCRIPTION
Trophy names/descriptions in the Trophies list were being cut off with "..." at one/two lines. Tapping a row now opens a full-detail popup (name, description, icon, earned date) styled like the app's other dialogs, so the list rows can keep their compact truncated preview.