### PR TITLE
Add CAS image sharpening for the video stream

### DIFF
--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -101,7 +101,7 @@ jobs:
             ## CloudPad Beta Release ${{ env.VERSION }}
 
             ### Updates
-            - Tapping a trophy in the Trophies list (Quick Settings or the full-screen Trophies screen) now opens a detail pop-up with the full trophy name, description, icon, and earned date, so long trophy names/descriptions are no longer cut off with "...".
+            - Added CAS (Contrast Adaptive Sharpening) image sharpening for the video stream, with a toggle and 1-10 sharpening level slider in both Settings and the in-stream Quick Settings panel. Changes apply live while streaming — no need to restart.
 
             ### APK
             Attached release asset:

--- a/android/app/src/main/java/com/metallic/chiaki/common/Preferences.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/common/Preferences.kt
@@ -55,6 +55,10 @@ class Preferences(context: Context)
 		const val CLOUD_BITRATE_MAX_KBPS = 200000
 		const val CLOUD_BITRATE_DEFAULT_KBPS = 20000
 
+		const val CAS_SHARPENING_LEVEL_MIN = 1
+		const val CAS_SHARPENING_LEVEL_MAX = 10
+		const val CAS_SHARPENING_LEVEL_DEFAULT = 1
+
 		private const val CLOUD_STORE_LOCALE_KEY = "cloud_store_locale"
 		private const val LEGACY_CLOUD_LANGUAGE_PSCLOUD_KEY = "cloud_language_pscloud"
 
@@ -123,6 +127,16 @@ class Preferences(context: Context)
 	var pipEnabled
 		get() = sharedPreferences.getBoolean(pipEnabledKey, true)
 		set(value) { sharedPreferences.edit().putBoolean(pipEnabledKey, value).apply() }
+
+	val casSharpeningEnabledKey get() = resources.getString(R.string.preferences_cas_sharpening_enabled_key)
+	var casSharpeningEnabled
+		get() = sharedPreferences.getBoolean(casSharpeningEnabledKey, false)
+		set(value) { sharedPreferences.edit().putBoolean(casSharpeningEnabledKey, value).apply() }
+
+	val casSharpeningLevelKey get() = resources.getString(R.string.preferences_cas_sharpening_level_key)
+	var casSharpeningLevel
+		get() = sharedPreferences.getInt(casSharpeningLevelKey, CAS_SHARPENING_LEVEL_DEFAULT).coerceIn(CAS_SHARPENING_LEVEL_MIN, CAS_SHARPENING_LEVEL_MAX)
+		set(value) { sharedPreferences.edit().putInt(casSharpeningLevelKey, value.coerceIn(CAS_SHARPENING_LEVEL_MIN, CAS_SHARPENING_LEVEL_MAX)).apply() }
 
 	val swapCrossMoonKey get() = resources.getString(R.string.preferences_swap_cross_moon_key)
 	var swapCrossMoon

--- a/android/app/src/main/java/com/metallic/chiaki/session/StreamSession.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/session/StreamSession.kt
@@ -452,6 +452,20 @@ class StreamSession(val connectInfo: ConnectInfo, val logManager: LogManager, va
 		})
 	}
 
+	/** Like [attachToTextureView], but the Surface comes from a [com.metallic.chiaki.stream.CasVideoSurfaceView]'s
+	 *  off-screen SurfaceTexture (an external OES texture sampled by its CAS shader) instead of a
+	 *  TextureView's own on-screen one — the decoder doesn't know or care which. */
+	fun attachToCasSurfaceView(view: com.metallic.chiaki.stream.CasVideoSurfaceView)
+	{
+		view.onSurfaceReady = { readySurface ->
+			if(surface == null)
+			{
+				surface = readySurface
+				session?.setSurface(readySurface)
+			}
+		}
+	}
+
 	fun attachToTextureView(textureView: TextureView)
 	{
 		textureView.surfaceTextureListener = object: TextureView.SurfaceTextureListener {

--- a/android/app/src/main/java/com/metallic/chiaki/settings/SettingsFragment.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/settings/SettingsFragment.kt
@@ -36,6 +36,7 @@ class DataStore(val preferences: Preferences): PreferenceDataStore()
 		preferences.motionEnabledKey -> preferences.motionEnabled
 		preferences.buttonHapticEnabledKey -> preferences.buttonHapticEnabled
 		preferences.pipEnabledKey -> preferences.pipEnabled
+		preferences.casSharpeningEnabledKey -> preferences.casSharpeningEnabled
 		else -> defValue
 	}
 
@@ -48,6 +49,7 @@ class DataStore(val preferences: Preferences): PreferenceDataStore()
 			preferences.motionEnabledKey -> preferences.motionEnabled = value
 			preferences.buttonHapticEnabledKey -> preferences.buttonHapticEnabled = value
 			preferences.pipEnabledKey -> preferences.pipEnabled = value
+			preferences.casSharpeningEnabledKey -> preferences.casSharpeningEnabled = value
 		}
 	}
 
@@ -96,6 +98,7 @@ class DataStore(val preferences: Preferences): PreferenceDataStore()
 	override fun getInt(key: String, defValue: Int) = when (key) {
 		preferences.cloudBitratePscloudKey -> preferences.getCloudBitratePscloud() / 1000
 		preferences.cloudBitratePsnowKey -> preferences.getCloudBitratePsnow() / 1000
+		preferences.casSharpeningLevelKey -> preferences.casSharpeningLevel
 		else -> defValue
 	}
 
@@ -103,6 +106,7 @@ class DataStore(val preferences: Preferences): PreferenceDataStore()
 		when (key) {
 			preferences.cloudBitratePscloudKey -> preferences.setCloudBitratePscloud(value * 1000)
 			preferences.cloudBitratePsnowKey -> preferences.setCloudBitratePsnow(value * 1000)
+			preferences.casSharpeningLevelKey -> preferences.casSharpeningLevel = value
 		}
 	}
 }
@@ -188,6 +192,17 @@ class SettingsFragment: PreferenceFragmentCompat(), TitleFragment
 		viewModel.bitrateAuto.observe(this, Observer {
 			bitratePreference?.summaryProvider = bitrateSummaryProvider
 		})
+
+		// CAS sharpening: the level slider only ever makes sense while the effect is on, and
+		// disabling the toggle must visibly remove any suggestion that the leftover slider
+		// value is still doing anything — hidden outright rather than just disabled/greyed.
+		val casLevelPreference = preferenceScreen.findPreference<SeekBarPreference>(getString(R.string.preferences_cas_sharpening_level_key))
+		casLevelPreference?.isVisible = preferences.casSharpeningEnabled
+		preferenceScreen.findPreference<SwitchPreference>(getString(R.string.preferences_cas_sharpening_enabled_key))
+			?.setOnPreferenceChangeListener { _, newValue ->
+				casLevelPreference?.isVisible = newValue as? Boolean ?: false
+				true
+			}
 
 		preferenceScreen.findPreference<ListPreference>(getString(R.string.preferences_codec_key))?.let {
 			it.entryValues = Preferences.codecAll.map { codec -> codec.value }.toTypedArray()

--- a/android/app/src/main/java/com/metallic/chiaki/stream/CasVideoSurfaceView.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/stream/CasVideoSurfaceView.kt
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
+
+package com.metallic.chiaki.stream
+
+import android.content.Context
+import android.graphics.SurfaceTexture
+import android.opengl.GLES11Ext
+import android.opengl.GLES20
+import android.opengl.GLSurfaceView
+import android.os.Handler
+import android.os.Looper
+import android.util.AttributeSet
+import android.util.Log
+import android.view.Surface
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.FloatBuffer
+import javax.microedition.khronos.egl.EGLConfig
+import javax.microedition.khronos.opengles.GL10
+
+/**
+ * Renders the decoded video stream through an off-screen [SurfaceTexture] (the MediaCodec output
+ * target, unrelated to this view's own on-screen EGL surface) sampled by a single-pass Contrast
+ * Adaptive Sharpening fragment shader, so decoded frames can be sharpened before they hit the
+ * screen without touching the native decoder at all — MediaCodec/ANativeWindow doesn't care what
+ * kind of Surface it's handed. See [onSurfaceReady] for how the decoder's target Surface is handed
+ * back out to [com.metallic.chiaki.session.StreamSession].
+ *
+ * The EGL context is preserved across pause/resume ([GLSurfaceView.setPreserveEGLContextOnPause])
+ * so the external texture/SurfaceTexture/Surface triple is created exactly once for this view's
+ * lifetime — [Renderer.onSurfaceCreated] can otherwise re-fire after a resume, which would hand
+ * out a second Surface the decoder never sees.
+ */
+class CasVideoSurfaceView @JvmOverloads constructor(
+	context: Context, attrs: AttributeSet? = null
+) : GLSurfaceView(context, attrs)
+{
+	/** Invoked once, on the main thread, as soon as the decoder's target [Surface] exists. */
+	var onSurfaceReady: ((Surface) -> Unit)? = null
+
+	private val mainHandler = Handler(Looper.getMainLooper())
+	private val renderer = CasRenderer()
+
+	init
+	{
+		setEGLContextClientVersion(2)
+		preserveEGLContextOnPause = true
+		setRenderer(renderer)
+		renderMode = RENDERMODE_WHEN_DIRTY
+	}
+
+	/** Stream resolution (not this view's on-screen size) — the CAS shader's tap spacing is
+	 *  sized in decoded-texture texels, matching what the decoder was actually configured with
+	 *  (see [com.metallic.chiaki.lib.ConnectVideoProfile]), not the on-screen viewport. */
+	fun setVideoSize(width: Int, height: Int) = renderer.setVideoSize(width, height)
+
+	fun setSharpening(enabled: Boolean, level: Int) = renderer.setSharpening(enabled, level)
+
+	private inner class CasRenderer : Renderer
+	{
+		private var textureId = 0
+		private var surfaceTexture: SurfaceTexture? = null
+		private var program = 0
+		private var aPositionLoc = 0
+		private var aTexCoordLoc = 0
+		private var uSTMatrixLoc = 0
+		private var uTexelSizeLoc = 0
+		private var uSharpnessLoc = 0
+		private var uEnabledLoc = 0
+
+		private val stMatrix = FloatArray(16)
+
+		@Volatile private var videoWidth = 1
+		@Volatile private var videoHeight = 1
+		@Volatile private var sharpeningEnabled = false
+		@Volatile private var sharpnessT = CAS_SHARPNESS_MIN
+
+		fun setVideoSize(width: Int, height: Int)
+		{
+			videoWidth = width.coerceAtLeast(1)
+			videoHeight = height.coerceAtLeast(1)
+		}
+
+		fun setSharpening(enabled: Boolean, level: Int)
+		{
+			sharpeningEnabled = enabled
+			sharpnessT = (level.coerceIn(1, 10) / 10f).coerceIn(CAS_SHARPNESS_MIN, 1f)
+			requestRender()
+		}
+
+		override fun onSurfaceCreated(gl: GL10?, config: EGLConfig?)
+		{
+			// Context is preserved across pause/resume, so this only runs once per view lifetime.
+			if(surfaceTexture != null)
+				return
+
+			GLES20.glClearColor(0f, 0f, 0f, 1f)
+
+			val textures = IntArray(1)
+			GLES20.glGenTextures(1, textures, 0)
+			textureId = textures[0]
+			GLES20.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, textureId)
+			GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_LINEAR)
+			GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_LINEAR)
+			GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_WRAP_S, GLES20.GL_CLAMP_TO_EDGE)
+			GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_WRAP_T, GLES20.GL_CLAMP_TO_EDGE)
+
+			val st = SurfaceTexture(textureId)
+			st.setOnFrameAvailableListener { requestRender() }
+			surfaceTexture = st
+
+			program = buildProgram(VERTEX_SHADER, CAS_FRAGMENT_SHADER)
+			aPositionLoc = GLES20.glGetAttribLocation(program, "aPosition")
+			aTexCoordLoc = GLES20.glGetAttribLocation(program, "aTexCoord")
+			uSTMatrixLoc = GLES20.glGetUniformLocation(program, "uSTMatrix")
+			uTexelSizeLoc = GLES20.glGetUniformLocation(program, "uTexelSize")
+			uSharpnessLoc = GLES20.glGetUniformLocation(program, "uSharpness")
+			uEnabledLoc = GLES20.glGetUniformLocation(program, "uEnabled")
+
+			val surface = Surface(st)
+			mainHandler.post { onSurfaceReady?.invoke(surface) }
+		}
+
+		override fun onSurfaceChanged(gl: GL10?, width: Int, height: Int)
+		{
+			GLES20.glViewport(0, 0, width, height)
+		}
+
+		override fun onDrawFrame(gl: GL10?)
+		{
+			val st = surfaceTexture ?: return
+			st.updateTexImage()
+			st.getTransformMatrix(stMatrix)
+
+			GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT)
+			GLES20.glUseProgram(program)
+
+			GLES20.glActiveTexture(GLES20.GL_TEXTURE0)
+			GLES20.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, textureId)
+
+			quadVertices.position(0)
+			GLES20.glVertexAttribPointer(aPositionLoc, 2, GLES20.GL_FLOAT, false, VERTEX_STRIDE, quadVertices)
+			GLES20.glEnableVertexAttribArray(aPositionLoc)
+
+			quadTexCoords.position(0)
+			GLES20.glVertexAttribPointer(aTexCoordLoc, 2, GLES20.GL_FLOAT, false, VERTEX_STRIDE, quadTexCoords)
+			GLES20.glEnableVertexAttribArray(aTexCoordLoc)
+
+			GLES20.glUniformMatrix4fv(uSTMatrixLoc, 1, false, stMatrix, 0)
+			GLES20.glUniform2f(uTexelSizeLoc, 1f / videoWidth, 1f / videoHeight)
+			GLES20.glUniform1f(uSharpnessLoc, sharpnessT)
+			GLES20.glUniform1f(uEnabledLoc, if(sharpeningEnabled) 1f else 0f)
+
+			GLES20.glDrawArrays(GLES20.GL_TRIANGLE_STRIP, 0, 4)
+
+			GLES20.glDisableVertexAttribArray(aPositionLoc)
+			GLES20.glDisableVertexAttribArray(aTexCoordLoc)
+		}
+	}
+
+	companion object
+	{
+		private const val TAG = "CasVideoSurfaceView"
+
+		/** Slider value 1 still applies a small amount of sharpening rather than none — the
+		 *  toggle, not the slider, is what fully disables the effect (uEnabled uniform). */
+		private const val CAS_SHARPNESS_MIN = 0.1f
+
+		private const val VERTEX_STRIDE = 2 * 4
+
+		private val quadVertices = floatBufferOf(
+			-1f, -1f,
+			1f, -1f,
+			-1f, 1f,
+			1f, 1f
+		)
+
+		private val quadTexCoords = floatBufferOf(
+			0f, 0f,
+			1f, 0f,
+			0f, 1f,
+			1f, 1f
+		)
+
+		private fun floatBufferOf(vararg values: Float): FloatBuffer =
+			ByteBuffer.allocateDirect(values.size * 4).order(ByteOrder.nativeOrder()).asFloatBuffer().apply {
+				put(values)
+				position(0)
+			}
+
+		private const val VERTEX_SHADER = """
+			attribute vec4 aPosition;
+			attribute vec2 aTexCoord;
+			uniform mat4 uSTMatrix;
+			varying vec2 vTexCoord;
+			void main()
+			{
+				gl_Position = aPosition;
+				vTexCoord = (uSTMatrix * vec4(aTexCoord, 0.0, 1.0)).xy;
+			}
+		"""
+
+		// AMD FidelityFX CAS (sharpen-only, no upscale), 5-tap "plus" pattern. uSharpness is
+		// the normalized 0..1 slider value; uEnabled gates the whole effect so a disabled
+		// toggle is a pure passthrough regardless of whatever level the slider was left at.
+		private const val CAS_FRAGMENT_SHADER = """
+			#extension GL_OES_EGL_image_external : require
+			precision mediump float;
+			varying vec2 vTexCoord;
+			uniform samplerExternalOES sTexture;
+			uniform vec2 uTexelSize;
+			uniform float uSharpness;
+			uniform float uEnabled;
+
+			void main()
+			{
+				vec3 centerColor = texture2D(sTexture, vTexCoord).rgb;
+				if(uEnabled < 0.5)
+				{
+					gl_FragColor = vec4(centerColor, 1.0);
+					return;
+				}
+
+				vec3 n = texture2D(sTexture, vTexCoord + vec2(0.0, -uTexelSize.y)).rgb;
+				vec3 s = texture2D(sTexture, vTexCoord + vec2(0.0,  uTexelSize.y)).rgb;
+				vec3 w = texture2D(sTexture, vTexCoord + vec2(-uTexelSize.x, 0.0)).rgb;
+				vec3 e = texture2D(sTexture, vTexCoord + vec2( uTexelSize.x, 0.0)).rgb;
+
+				vec3 mn = min(min(min(min(n, s), w), e), centerColor);
+				vec3 mx = max(max(max(max(n, s), w), e), centerColor);
+
+				vec3 rcpMx = 1.0 / max(mx, vec3(0.0001));
+				vec3 amp = clamp(min(mn, 2.0 - mx) * rcpMx, 0.0, 1.0);
+				amp = inversesqrt(amp);
+
+				float peak = 8.0 - 3.0 * uSharpness;
+				vec3 weight = -1.0 / (amp * peak);
+				vec3 rcpWeight = 1.0 / (1.0 + 4.0 * weight);
+
+				vec3 window = n + s + w + e;
+				vec3 sharpened = clamp((window * weight + centerColor) * rcpWeight, 0.0, 1.0);
+				gl_FragColor = vec4(sharpened, 1.0);
+			}
+		"""
+
+		private fun compileShader(type: Int, source: String): Int
+		{
+			val shader = GLES20.glCreateShader(type)
+			GLES20.glShaderSource(shader, source)
+			GLES20.glCompileShader(shader)
+			val status = IntArray(1)
+			GLES20.glGetShaderiv(shader, GLES20.GL_COMPILE_STATUS, status, 0)
+			if(status[0] == 0)
+			{
+				Log.e(TAG, "Shader compile failed: ${GLES20.glGetShaderInfoLog(shader)}")
+				GLES20.glDeleteShader(shader)
+				return 0
+			}
+			return shader
+		}
+
+		private fun buildProgram(vertexSource: String, fragmentSource: String): Int
+		{
+			val vertexShader = compileShader(GLES20.GL_VERTEX_SHADER, vertexSource)
+			val fragmentShader = compileShader(GLES20.GL_FRAGMENT_SHADER, fragmentSource)
+			val program = GLES20.glCreateProgram()
+			GLES20.glAttachShader(program, vertexShader)
+			GLES20.glAttachShader(program, fragmentShader)
+			GLES20.glLinkProgram(program)
+			val status = IntArray(1)
+			GLES20.glGetProgramiv(program, GLES20.GL_LINK_STATUS, status, 0)
+			if(status[0] == 0)
+			{
+				Log.e(TAG, "Program link failed: ${GLES20.glGetProgramInfoLog(program)}")
+			}
+			return program
+		}
+	}
+}

--- a/android/app/src/main/java/com/metallic/chiaki/stream/QuickSettingsPanel.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/stream/QuickSettingsPanel.kt
@@ -104,7 +104,8 @@ class QuickSettingsPanel(
 	private val gameImageUrl: String,
 	private val getDisplayMode: () -> TransformMode,
 	private val onDisplayModeChanged: (TransformMode) -> Unit,
-	private val requestMicPermission: (onResult: (Boolean) -> Unit) -> Unit
+	private val requestMicPermission: (onResult: (Boolean) -> Unit) -> Unit,
+	private val onCasSharpeningChanged: (enabled: Boolean, level: Int) -> Unit
 ) {
 	private val panel = StreamQuickSettingsPanelBinding.inflate(activity.layoutInflater).apply {
 		// root.focusable=true (see stream_quick_settings_panel.xml) exists only so a touch tap
@@ -373,6 +374,33 @@ class QuickSettingsPanel(
 			preferences.pipEnabled = isChecked
 		}
 
+		// CAS Image Sharpening: applies to the live GL renderer immediately, in the same
+		// listener that flips the toggle/moves the slider — no Save button, same as every
+		// other row here. Slider only exists visually while the toggle is on.
+		panel.quickSettingsCasRow.quickSettingsRowLabel.text = activity.getString(R.string.preferences_cas_sharpening_enabled_title)
+		panel.quickSettingsCasSeekBarRow.quickSettingsSeekBar.max = Preferences.CAS_SHARPENING_LEVEL_MAX - Preferences.CAS_SHARPENING_LEVEL_MIN
+		panel.quickSettingsCasSeekBarRow.quickSettingsSeekBar.keyProgressIncrement = 1
+		panel.quickSettingsCasRow.quickSettingsRowSwitch.setOnCheckedChangeListener { _, isChecked ->
+			preferences.casSharpeningEnabled = isChecked
+			panel.quickSettingsCasSeekBarRow.root.visibility = if(isChecked) View.VISIBLE else View.GONE
+			onCasSharpeningChanged(isChecked, preferences.casSharpeningLevel)
+		}
+		panel.quickSettingsCasSeekBarRow.quickSettingsSeekBar.setOnSeekBarChangeListener(object: SeekBar.OnSeekBarChangeListener
+		{
+			override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean)
+			{
+				val value = progress + Preferences.CAS_SHARPENING_LEVEL_MIN
+				updateCasSeekBarLabel(value)
+				if(fromUser)
+				{
+					preferences.casSharpeningLevel = value
+					onCasSharpeningChanged(preferences.casSharpeningEnabled, value)
+				}
+			}
+			override fun onStartTrackingTouch(seekBar: SeekBar) {}
+			override fun onStopTrackingTouch(seekBar: SeekBar) {}
+		})
+
 		// Window Size applies immediately too, as soon as a new option is checked.
 		panel.quickSettingsDisplayModeToggle.addOnButtonCheckedListener { _, checkedId, isChecked ->
 			if(!isChecked) return@addOnButtonCheckedListener
@@ -426,7 +454,8 @@ class QuickSettingsPanel(
 			panel.quickSettingsStatsRow.quickSettingsRowSwitch, panel.quickSettingsOscRow.quickSettingsRowSwitch,
 			panel.quickSettingsTouchpadRow.quickSettingsRowSwitch, panel.quickSettingsMicrophoneRow.quickSettingsRowSwitch,
 			panel.quickSettingsMotionRow.quickSettingsRowSwitch, panel.quickSettingsHapticsRow.quickSettingsRowSwitch,
-			panel.quickSettingsPipRow.quickSettingsRowSwitch, panel.quickSettingsTrophiesRefreshButton,
+			panel.quickSettingsPipRow.quickSettingsRowSwitch, panel.quickSettingsCasRow.quickSettingsRowSwitch,
+			panel.quickSettingsCasSeekBarRow.quickSettingsSeekBar, panel.quickSettingsTrophiesRefreshButton,
 			panel.quickSettingsFriendsRefreshButton,
 			panel.quickSettingsFriendChatBackButton, panel.quickSettingsFriendChatRefreshButton,
 			panel.quickSettingsFriendChatInput, panel.quickSettingsFriendChatSendButton,
@@ -908,6 +937,12 @@ class QuickSettingsPanel(
 		addFocusHighlight(row.quickSettingsDropdownSpinner, pyluxAccentColor)
 	}
 
+	private fun updateCasSeekBarLabel(value: Int)
+	{
+		panel.quickSettingsCasSeekBarRow.quickSettingsSeekBarLabel.text =
+			activity.getString(R.string.quick_settings_cas_sharpening_level, value)
+	}
+
 	private fun addSeekBarRow(
 		container: LinearLayout,
 		summaryRes: Int,
@@ -973,6 +1008,11 @@ class QuickSettingsPanel(
 		panel.quickSettingsMotionRow.quickSettingsRowSwitch.isChecked = preferences.motionEnabled
 		panel.quickSettingsHapticsRow.quickSettingsRowSwitch.isChecked = preferences.buttonHapticEnabled
 		panel.quickSettingsPipRow.quickSettingsRowSwitch.isChecked = preferences.pipEnabled
+
+		panel.quickSettingsCasRow.quickSettingsRowSwitch.isChecked = preferences.casSharpeningEnabled
+		panel.quickSettingsCasSeekBarRow.root.visibility = if(preferences.casSharpeningEnabled) View.VISIBLE else View.GONE
+		panel.quickSettingsCasSeekBarRow.quickSettingsSeekBar.progress = preferences.casSharpeningLevel - Preferences.CAS_SHARPENING_LEVEL_MIN
+		updateCasSeekBarLabel(preferences.casSharpeningLevel)
 
 		panel.root.translationX = panelWidthPx
 		if(!dialog.isShowing) dialog.show()

--- a/android/app/src/main/java/com/metallic/chiaki/stream/StreamActivity.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/stream/StreamActivity.kt
@@ -161,7 +161,8 @@ class StreamActivity : AppCompatActivity(), View.OnSystemUiVisibilityChangeListe
 			requestMicPermission = { onResult ->
 				pendingMicPermissionCallback = onResult
 				micPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
-			}
+			},
+			onCasSharpeningChanged = { enabled, level -> binding.surfaceView.setSharpening(enabled, level) }
 		)
 
 		// Handle back button — on TV show a disconnect confirmation dialog; on touch,
@@ -182,7 +183,10 @@ class StreamActivity : AppCompatActivity(), View.OnSystemUiVisibilityChangeListe
 		})
 
 		//viewModel.session.attachToTextureView(textureView)
-		viewModel.session.attachToSurfaceView(binding.surfaceView)
+		val videoProfile = connectInfo.videoProfile
+		binding.surfaceView.setVideoSize(videoProfile.width, videoProfile.height)
+		binding.surfaceView.setSharpening(prefs.casSharpeningEnabled, prefs.casSharpeningLevel)
+		viewModel.session.attachToCasSurfaceView(binding.surfaceView)
 		viewModel.session.state.observe(this, Observer { this.stateChanged(it) })
 		adjustStreamViewAspect()
 
@@ -228,6 +232,9 @@ class StreamActivity : AppCompatActivity(), View.OnSystemUiVisibilityChangeListe
 		Log.i("StreamActivity", "onResume: pip=$isInPictureInPictureMode session=${viewModel.session.session != null}")
 		hideSystemUI()
 
+		// Paired with viewModel.session.resume() — the GL render thread should be alive
+		// exactly when the decoder is (see CasVideoSurfaceView's own doc comment).
+		binding.surfaceView.onResume()
 		viewModel.session.resume()
 	}
 
@@ -238,6 +245,7 @@ class StreamActivity : AppCompatActivity(), View.OnSystemUiVisibilityChangeListe
 		if (!isInPictureInPictureMode)
 		{
 			viewModel.session.skipNativeSurfaceCleanup = false
+			binding.surfaceView.onPause()
 			viewModel.session.pause()
 		}
 	}
@@ -250,6 +258,7 @@ class StreamActivity : AppCompatActivity(), View.OnSystemUiVisibilityChangeListe
 		if (!isInPictureInPictureMode)
 		{
 			viewModel.session.skipNativeSurfaceCleanup = false
+			binding.surfaceView.onPause()
 			viewModel.session.pause()
 		}
 	}
@@ -344,6 +353,7 @@ class StreamActivity : AppCompatActivity(), View.OnSystemUiVisibilityChangeListe
 			if (activityStopped)
 			{
 				Log.i("StreamActivity", "handlePipChanged: PiP dismissed while stopped, shutting down session")
+				binding.surfaceView.onPause()
 				viewModel.session.pause()
 			}
 			else if (!isFinishing)

--- a/android/app/src/main/res/layout/activity_stream.xml
+++ b/android/app/src/main/res/layout/activity_stream.xml
@@ -14,7 +14,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_gravity="center">
-        <SurfaceView
+        <com.metallic.chiaki.stream.CasVideoSurfaceView
             android:id="@+id/surfaceView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"/>

--- a/android/app/src/main/res/layout/stream_quick_settings_panel.xml
+++ b/android/app/src/main/res/layout/stream_quick_settings_panel.xml
@@ -277,6 +277,18 @@
             <include layout="@layout/item_quick_settings_switch" android:id="@+id/quickSettingsHapticsRow" />
             <include layout="@layout/item_quick_settings_switch" android:id="@+id/quickSettingsPipRow" />
 
+            <com.google.android.material.divider.MaterialDivider
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp" />
+
+            <TextView
+                style="@style/QuickSettingsSectionLabel"
+                android:text="@string/preferences_category_title_cas_sharpening" />
+
+            <include layout="@layout/item_quick_settings_switch" android:id="@+id/quickSettingsCasRow" />
+            <include layout="@layout/item_quick_settings_seekbar" android:id="@+id/quickSettingsCasSeekBarRow" />
+
         </LinearLayout>
 
     </ScrollView>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -153,6 +153,11 @@
     <string name="preferences_motion_enabled_summary">Use device\'s motion sensors for controller motion</string>
     <string name="preferences_button_haptic_enabled_title">Touch Haptics</string>
     <string name="preferences_button_haptic_enabled_summary">Vibrate the phone on touchscreen button presses</string>
+    <string name="preferences_category_title_cas_sharpening">CAS Image Sharpening</string>
+    <string name="preferences_cas_sharpening_enabled_title">Enable CAS Image Sharpening</string>
+    <string name="preferences_cas_sharpening_enabled_summary">Sharpens the stream image in real time using AMD FidelityFX Contrast Adaptive Sharpening</string>
+    <string name="preferences_cas_sharpening_level_title">Sharpening Level</string>
+    <string name="quick_settings_cas_sharpening_level">Sharpening Level: %d</string>
     <string name="quick_settings_title">Quick Settings</string>
     <string name="quick_settings_close">Close</string>
     <string name="quick_settings_current_game">Current game: %s</string>
@@ -321,6 +326,8 @@
     <string name="preferences_cloud_resolution_psnow_key">cloud_resolution_psnow</string>
     <string name="preferences_cloud_resolution_pscloud_key">cloud_resolution_pscloud</string>
     <string name="preferences_pip_enabled_key">pip_enabled</string>
+    <string name="preferences_cas_sharpening_enabled_key">cas_sharpening_enabled</string>
+    <string name="preferences_cas_sharpening_level_key">cas_sharpening_level</string>
     <string name="donation_dialog_title">Support CloudPad</string>
     <string name="donation_dialog_body">CloudPad is built by the community. If you enjoy using it, please consider supporting its development. Your contribution helps fund continued updates and keeps the project alive.</string>
     <!-- Play Console product title and localized price, shown on each tier button -->

--- a/android/app/src/main/res/xml/preferences.xml
+++ b/android/app/src/main/res/xml/preferences.xml
@@ -94,6 +94,27 @@
     </PreferenceCategory>
 
     <PreferenceCategory
+        app:key="category_cas_sharpening"
+        app:title="@string/preferences_category_title_cas_sharpening">
+        <SwitchPreference
+            app:key="@string/preferences_cas_sharpening_enabled_key"
+            app:title="@string/preferences_cas_sharpening_enabled_title"
+            app:summary="@string/preferences_cas_sharpening_enabled_summary"
+            app:defaultValue="false"
+            app:icon="@drawable/ic_resolution"/>
+
+        <SeekBarPreference
+            app:key="@string/preferences_cas_sharpening_level_key"
+            app:title="@string/preferences_cas_sharpening_level_title"
+            app:min="1"
+            android:max="10"
+            app:seekBarIncrement="1"
+            app:defaultValue="1"
+            app:showSeekBarValue="true"
+            app:icon="@drawable/ic_resolution"/>
+    </PreferenceCategory>
+
+    <PreferenceCategory
         app:key="category_stream"
         app:title="@string/preferences_category_title_stream">
         <ListPreference


### PR DESCRIPTION
Decodes into an off-screen SurfaceTexture (external OES texture) rendered through an AMD FidelityFX CAS fragment shader instead of straight to the display surface, so the stream can be sharpened without touching the native decoder. Toggle + 1-10 level slider added to both Settings and the in-stream Quick Settings panel, applying live while connected.