### PR TITLE
Theme-colour the sort/search icons and fix search bar auto-close

### DIFF
--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -120,7 +120,10 @@ jobs:
             ## CloudPad Beta Release ${{ env.VERSION }}
 
             ### Updates
-            - No app changes in this release — it's a test of the restored release signing only. If it installs as an update over your existing app (no uninstall needed), signing is confirmed fixed for future releases. If it doesn't, you'll need to uninstall and reinstall this one time; every release after this point should then update normally.
+            - Sort selection highlight in the game library now uses the app's selected theme colour instead of always showing blue.
+            - Search bar no longer auto-closes when scrolling the game tiles list — it now stays open until you tap the search icon again.
+            - Search icon now highlights in the theme colour while the search bar is open, and returns to normal when closed.
+            - Tapping the search icon no longer pops open the keyboard automatically — it only appears once you tap into the search field itself.
 
             ### APK
             Attached release asset:

--- a/android/app/src/main/java/com/metallic/chiaki/main/CloudPlayFragment.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/main/CloudPlayFragment.kt
@@ -148,7 +148,6 @@ class CloudPlayFragment : Fragment() {
         setupCloudTabs()
         setupSearchView()
         setupSettingsFab()
-        setupScrollListener()
         setupLoginButton()
 
         // Check login status BEFORE observing ViewModel to prevent cached games from showing.
@@ -410,24 +409,14 @@ class CloudPlayFragment : Fragment() {
             binding.searchView.layoutParams = binding.searchView.layoutParams.apply {
                 height = android.view.ViewGroup.LayoutParams.WRAP_CONTENT
             }
-            // Focus the inner EditText directly so TV DPad can reach it
+            // Focus the inner EditText directly so TV DPad can reach it, but don't show the
+            // keyboard yet — it should only appear once the user taps into the field.
             val queryEditText =
                 binding.searchView.findViewById<android.view.View>(androidx.appcompat.R.id.search_src_text)
                     ?: binding.searchView
             queryEditText.isFocusableInTouchMode = true
             queryEditText.requestFocus()
-            val imm =
-                requireContext().getSystemService(android.content.Context.INPUT_METHOD_SERVICE) as android.view.inputmethod.InputMethodManager
-            imm.showSoftInput(
-                queryEditText,
-                android.view.inputmethod.InputMethodManager.SHOW_IMPLICIT
-            )
-            binding.headerSearchButton.setColorFilter(
-                resources.getColor(
-                    android.R.color.white,
-                    null
-                )
-            )
+            binding.headerSearchButton.setColorFilter(resolveAccentColor())
             binding.headerSearchButton.alpha = 1.0f
         } else {
             collapseSearchBar()
@@ -439,25 +428,6 @@ class CloudPlayFragment : Fragment() {
             )
             binding.headerSearchButton.alpha = 0.45f
         }
-    }
-
-    private fun setupScrollListener() {
-        // Hide search bar when scrolling
-        binding.gamesRecyclerView.addOnScrollListener(object :
-            androidx.recyclerview.widget.RecyclerView.OnScrollListener() {
-            override fun onScrolled(
-                recyclerView: androidx.recyclerview.widget.RecyclerView,
-                dx: Int,
-                dy: Int
-            ) {
-                super.onScrolled(recyclerView, dx, dy)
-                if (dy > 0 && isSearchExpanded) {
-                    // Scrolling down - collapse search
-                    isSearchExpanded = false
-                    collapseSearchBar()
-                }
-            }
-        })
     }
 
     private var isSearchExpanded = false

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -159,6 +159,7 @@
     <style name="AppTheme.AlertDialog" parent="Theme.MaterialComponents.Dialog.Alert">
         <item name="android:textColorPrimary">@android:color/primary_text_dark</item>
         <item name="colorPrimary">@color/accent</item>
+        <item name="colorControlActivated">?attr/pyluxAccent</item>
         <item name="materialButtonStyle">@style/AppTheme.AlertDialog.Button</item>
     </style>
 
@@ -175,21 +176,25 @@
     <style name="AppTheme.AlertDialog.Blue" parent="Theme.MaterialComponents.Dialog.Alert">
         <item name="android:textColorPrimary">@android:color/primary_text_dark</item>
         <item name="colorPrimary">@color/accent_blue</item>
+        <item name="colorControlActivated">?attr/pyluxAccent</item>
     </style>
 
     <style name="AppTheme.AlertDialog.Green" parent="Theme.MaterialComponents.Dialog.Alert">
         <item name="android:textColorPrimary">@android:color/primary_text_dark</item>
         <item name="colorPrimary">@color/accent_green</item>
+        <item name="colorControlActivated">?attr/pyluxAccent</item>
     </style>
 
     <style name="AppTheme.AlertDialog.Yellow" parent="Theme.MaterialComponents.Dialog.Alert">
         <item name="android:textColorPrimary">@android:color/primary_text_dark</item>
         <item name="colorPrimary">@color/accent_yellow</item>
+        <item name="colorControlActivated">?attr/pyluxAccent</item>
     </style>
 
     <style name="AppTheme.AlertDialog.Orange" parent="Theme.MaterialComponents.Dialog.Alert">
         <item name="android:textColorPrimary">@android:color/primary_text_dark</item>
         <item name="colorPrimary">@color/accent_orange</item>
+        <item name="colorControlActivated">?attr/pyluxAccent</item>
     </style>
 
     <style name="MageTheme" parent="Theme.MaterialComponents.NoActionBar">


### PR DESCRIPTION
- Sort selection highlight (both the header AlertDialog and settings FAB popup) now tracks the user's chosen theme accent instead of defaulting to Material's blue.
- Search bar no longer collapses when scrolling the game tiles list; it now only closes when the search icon is tapped again.
- Search icon tints to the theme accent while the search bar is open.
- Toggling the search icon no longer auto-opens the keyboard; it only appears once the user taps into the search field itself.