### PR TITLE
Don't auto-focus the search field when opening the search bar

### DIFF
--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -123,7 +123,7 @@ jobs:
             - Sort selection highlight in the game library now uses the app's selected theme colour instead of always showing blue.
             - Search bar no longer auto-closes when scrolling the game tiles list — it now stays open until you tap the search icon again.
             - Search icon now highlights in the theme colour while the search bar is open, and returns to normal when closed.
-            - Tapping the search icon no longer pops open the keyboard automatically — it only appears once you tap into the search field itself.
+            - Tapping the search icon no longer pops open the keyboard or puts focus in the search field automatically — both only happen once you tap into the search field yourself.
 
             ### APK
             Attached release asset:

--- a/android/app/src/main/java/com/metallic/chiaki/main/CloudPlayFragment.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/main/CloudPlayFragment.kt
@@ -409,13 +409,12 @@ class CloudPlayFragment : Fragment() {
             binding.searchView.layoutParams = binding.searchView.layoutParams.apply {
                 height = android.view.ViewGroup.LayoutParams.WRAP_CONTENT
             }
-            // Focus the inner EditText directly so TV DPad can reach it, but don't show the
-            // keyboard yet — it should only appear once the user taps into the field.
+            // Leave the inner EditText unfocused on open — focus (and the keyboard) should only
+            // land there when the user explicitly taps into the field themselves.
             val queryEditText =
                 binding.searchView.findViewById<android.view.View>(androidx.appcompat.R.id.search_src_text)
                     ?: binding.searchView
             queryEditText.isFocusableInTouchMode = true
-            queryEditText.requestFocus()
             binding.headerSearchButton.setColorFilter(resolveAccentColor())
             binding.headerSearchButton.alpha = 1.0f
         } else {


### PR DESCRIPTION
Focus should only land in the field when the user taps into it themselves, not just from toggling the search icon.