### PR TITLE
Fix PS5 titles failing to launch via classic PS Now catalogue

### DIFF
--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -120,10 +120,7 @@ jobs:
             ## CloudPad Beta Release ${{ env.VERSION }}
 
             ### Updates
-            - Added a Video Pacing setting (Smooth/Standard) to Settings and the in-stream Quick Menu. Smooth (default) keeps the buffered frame scheduling for steadier motion; Standard presents each frame the instant it decodes for the lowest latency. Changes apply immediately in the Quick Menu without a reconnect.
-            - Smooth pacing's buffering is now adaptive instead of a fixed cushion: it grows quickly for a few seconds after real network jitter causes a stutter, then shrinks back down to a low-latency floor once things are calm again, rather than holding extra latency all the time regardless of need.
-            - Fixed Cloud Play (PS Now/PS Cloud) streams sometimes getting stuck at a noticeably lower bitrate/quality than requested, with visible frame drops once a higher bitrate did come through. Root cause: the client was always reporting 0% network packet loss to the server regardless of actual conditions, so the server's own adaptive bitrate stepping had no real signal to react to. It now reports real conditions, so the server can back off gracefully instead of pushing a bitrate the network can't sustain.
-            - Fixed D-pad navigation getting stuck on the PS5 Library's Streamability filter icon: pressing up or down from it didn't reach the cloud icon or the games grid, since it was missing from the main screen's manual focus-routing table.
+            - Fixed PS5 titles served through the classic PS Now catalogue (e.g. Nioh 2 Remastered) failing to launch with "no game for this entitlement". The client never recognised PS5 in the store's platform data, so it silently requested a PS4 streaming session for a PS5-only title; it now detects PS5 correctly and requests the right session type.
 
             ### APK
             Attached release asset:

--- a/android/app/src/main/java/com/metallic/chiaki/cloudplay/api/PSGaikaiStreaming.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/cloudplay/api/PSGaikaiStreaming.kt
@@ -1597,8 +1597,10 @@ catch (e: Exception)
 			spec.put("ps3AuthCode", ps3AuthCode)
 			spec.put("streamServerAuthCode", ps3AuthCode)
 			
-			// Capabilities
-			capabilitiesArray.put("kratos")
+			// Capabilities — must match the virtType requested when fetching client IDs in
+			// Step 0 (kratos/cronos/konan), or Gaikai rejects PS5 titles served via the psnow
+			// entitlement flow with "noGameForEntitlementId" even though the entitlement is valid.
+			capabilitiesArray.put(virtType)
 		}
 		
 		// Set capabilities (common, but content differs by service)

--- a/android/app/src/main/java/com/metallic/chiaki/cloudplay/api/PSKamajiSession.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/cloudplay/api/PSKamajiSession.kt
@@ -796,16 +796,19 @@ class PSKamajiSession(
 				if (candidate.has("playable_platform"))
 				{
 					val playablePlatform = candidate.getJSONArray("playable_platform")
+					var hasPS5 = false
 					var hasPS4 = false
 					var hasPS3 = false
 					for (i in 0 until playablePlatform.length())
 					{
 						val platformStr = playablePlatform.getString(i)
-						if (platformStr.contains("PS4", ignoreCase = true)) hasPS4 = true
+						if (platformStr.contains("PS5", ignoreCase = true)) hasPS5 = true
+						else if (platformStr.contains("PS4", ignoreCase = true)) hasPS4 = true
 						else if (platformStr.contains("PS3", ignoreCase = true)) hasPS3 = true
 					}
 					detectedPlatform = when
 					{
+						hasPS5 -> "ps5"
 						hasPS4 -> "ps4"
 						hasPS3 -> "ps3"
 						else -> "ps4"
@@ -822,16 +825,19 @@ class PSKamajiSession(
 						if (playablePlatformObj.has("values"))
 						{
 							val values = playablePlatformObj.getJSONArray("values")
+							var hasPS5 = false
 							var hasPS4 = false
 							var hasPS3 = false
 							for (i in 0 until values.length())
 							{
 								val platformStr = values.getString(i)
-								if (platformStr.contains("PS4", ignoreCase = true)) hasPS4 = true
+								if (platformStr.contains("PS5", ignoreCase = true)) hasPS5 = true
+								else if (platformStr.contains("PS4", ignoreCase = true)) hasPS4 = true
 								else if (platformStr.contains("PS3", ignoreCase = true)) hasPS3 = true
 							}
 							detectedPlatform = when
 							{
+								hasPS5 -> "ps5"
 								hasPS4 -> "ps4"
 								hasPS3 -> "ps3"
 								else -> "ps4"
@@ -859,7 +865,11 @@ class PSKamajiSession(
 					// Only CUSA = PS4 and PPSA = PS5; everything else is PS3.
 					if (detectedPlatform == "ps4") {
 						val titlePrefix = Regex("-([A-Z]{4})\\d").find(productId)?.groupValues?.get(1)
-						if (titlePrefix != null && titlePrefix != "CUSA" && titlePrefix != "PPSA") {
+						if (titlePrefix == "PPSA") {
+							detectedPlatform = "ps5"
+							Log.i(TAG, "Step 0.5d: Refined platform to 'ps5' from title prefix '$titlePrefix' (store gave no playable_platform)")
+						}
+						else if (titlePrefix != null && titlePrefix != "CUSA") {
 							detectedPlatform = "ps3"
 							Log.i(TAG, "Step 0.5d: Refined platform to 'ps3' from title prefix '$titlePrefix' (store gave no playable_platform)")
 						}


### PR DESCRIPTION
Platform detection never recognised PS5 in the store's playable_platform data or PPSA title-ID prefix, so PS5-only titles (e.g. Nioh 2 Remastered) silently fell back to a PS4 session (virtType=kratos) and Gaikai rejected the entitlement with noGameForEntitlementId. Also fixes the psnow request spec's hardcoded "kratos" capability flag, which stayed PS4 even after platform was corrected, causing the same rejection to persist.