### PR TITLE
Fix trophy matching for titles where Sony inserts "the" mid-name

### DIFF
--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -120,8 +120,7 @@ jobs:
             ## CloudPad Beta Release ${{ env.VERSION }}
 
             ### Updates
-            - Fixed PS5 titles served through the classic PS Now catalogue (e.g. Nioh 2 Remastered) failing to launch with "no game for this entitlement". The client never recognised PS5 in the store's platform data, so it silently requested a PS4 streaming session for a PS5-only title; it now detects PS5 correctly and requests the right session type.
-            - Reverted the Video Pacing setting and the associated Cloud Play bitrate/diagnostics changes, keeping only the D-pad navigation fix for the Streamability filter icon from that changeset.
+            - Fixed trophy lists failing to appear for games whose store title omits a "the" that Sony's own trophy title includes mid-name (e.g. "Tainted Grail: Fall of Avalon" vs "Tainted Grail: The Fall of Avalon"). The trophy matcher now ignores standalone "the" tokens anywhere in the title when comparing names.
 
             ### APK
             Attached release asset:

--- a/android/app/src/main/java/com/metallic/chiaki/trophy/TrophyMatcher.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/trophy/TrophyMatcher.kt
@@ -25,6 +25,12 @@ object TrophyMatcher
 	private val nonAlphaNumPattern = Regex("[^a-z0-9]+")
 	private val whitespacePattern = Regex("\\s+")
 
+	/**
+	 * Store/catalogue titles and Sony's own trophyTitleName are inconsistent about including
+	 * the word "the" (e.g. a catalogue entry "Tainted Grail: Fall of Avalon" vs Sony's trophy
+	 * title "Tainted Grail: The Fall of Avalon"), and the word can appear mid-title rather than
+	 * as a leading article, so it must be dropped rather than just trimmed off the start.
+	 */
 	fun normalize(name: String): String
 	{
 		var result = name.lowercase()
@@ -32,7 +38,12 @@ object TrophyMatcher
 		result = platformSuffixPattern.replace(result, "")
 		result = editionSuffixPattern.replace(result, "")
 		result = nonAlphaNumPattern.replace(result, " ")
-		return whitespacePattern.replace(result, " ").trim()
+		result = whitespacePattern.replace(result, " ").trim()
+
+		return result
+			.split(" ")
+			.filter { token -> token != "the" }
+			.joinToString(" ")
 	}
 
 	/**

--- a/android/app/src/test/java/com/metallic/chiaki/trophy/TrophyMatcherTest.kt
+++ b/android/app/src/test/java/com/metallic/chiaki/trophy/TrophyMatcherTest.kt
@@ -38,7 +38,15 @@ class TrophyMatcherTest {
 
     @Test
     fun `normalize strips edition suffix`() {
-        assertEquals("the last of us part ii", TrophyMatcher.normalize("The Last of Us Part II - Digital Edition"))
+        assertEquals("last of us part ii", TrophyMatcher.normalize("The Last of Us Part II - Digital Edition"))
+    }
+
+    @Test
+    fun `normalize drops standalone the tokens anywhere in the title`() {
+        assertEquals(
+            "tainted grail fall of avalon",
+            TrophyMatcher.normalize("Tainted Grail: The Fall of Avalon")
+        )
     }
 
     @Test
@@ -131,6 +139,13 @@ class TrophyMatcherTest {
         val titles = listOf(title("NPWR001_00", "Uncharted 3", platform = "PS4"))
         val match = TrophyMatcher.findBestMatch("Uncharted II", "ps4", titles)
         assertNull(match)
+    }
+
+    @Test
+    fun `matches a catalogue title missing a mid-title the against Sony's trophy title`() {
+        val titles = listOf(title("NPWR001_00", "Tainted Grail: The Fall of Avalon", platform = "PS5"))
+        val match = TrophyMatcher.findBestMatch("Tainted Grail: Fall of Avalon", "ps5", titles)
+        assertEquals("NPWR001_00", match?.npCommunicationId)
     }
 
     @Test


### PR DESCRIPTION
TrophyMatcher normalized names but never dropped filler words, so a catalogue title like "Tainted Grail: Fall of Avalon" couldn't match Sony's own trophy title "Tainted Grail: The Fall of Avalon" — the word sits mid-title, so it broke both the exact and substring match passes. normalize() now strips standalone "the" tokens anywhere in the name.