### PR TITLE
Add trophy achieved counter, sort, and rarity filter

### DIFF
--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RELEASE_NOTES: >-
-        Limited the remaining on-screen controls to touches beginning within their visible areas and improved audio output startup reliability.
+        Added a trophies-achieved counter, sort by earned date, and rarity filtering to the Trophies screen and the in-stream Trophies quick menu.
 
     steps:
       - name: Checkout repo

--- a/android/app/src/main/java/com/metallic/chiaki/stream/QuickSettingsPanel.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/stream/QuickSettingsPanel.kt
@@ -25,6 +25,7 @@ import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.FrameLayout
 import android.widget.LinearLayout
+import android.widget.PopupMenu
 import android.widget.SeekBar
 import android.widget.Spinner
 import android.widget.TextView
@@ -64,10 +65,15 @@ import com.metallic.chiaki.session.StreamStateQuit
 import com.metallic.chiaki.settings.RemapAdapter
 import com.metallic.chiaki.settings.RemapItem
 import com.metallic.chiaki.trophy.TrophyAdapter
+import com.metallic.chiaki.trophy.TrophyFilterMode
 import com.metallic.chiaki.trophy.TrophyRepository
 import com.metallic.chiaki.trophy.TrophyResult
+import com.metallic.chiaki.trophy.TrophySortMode
 import com.metallic.chiaki.trophy.buildTrophyListItems
+import com.metallic.chiaki.trophy.filterModeToItemId
+import com.metallic.chiaki.trophy.itemIdToFilterMode
 import com.metallic.chiaki.trophy.showTrophyDetailDialog
+import com.metallic.chiaki.trophy.model.TrophyTitleDetail
 import com.metallic.chiaki.trophy.model.TrophyTitleSummary
 import com.pylux.stream.R
 import com.pylux.stream.databinding.ItemQuickSettingsDropdownBinding
@@ -320,6 +326,9 @@ class QuickSettingsPanel(
 	private val trophyRepository = TrophyRepository(preferences)
 	private val trophyAdapter = TrophyAdapter(onTrophyClick = { trophy -> showTrophyDetailDialog(activity, trophy) })
 	private var trophiesLoadedOnce = false
+	private var currentTrophyDetail: TrophyTitleDetail? = null
+	private var trophySortMode = TrophySortMode.DEFAULT
+	private var trophyFilterMode = TrophyFilterMode.DEFAULT
 
 	private val friendsRepository = FriendsRepository(preferences)
 	private val friendAdapter = FriendAdapter(
@@ -407,6 +416,8 @@ class QuickSettingsPanel(
 			trophiesScrollSettleHandler.postDelayed(reenableTrophiesRefreshFocusable, 300L)
 		}
 		panel.quickSettingsTrophiesRefreshButton.setOnClickListener { loadTrophies(forceRefresh = true) }
+		panel.quickSettingsTrophiesSortButton.setOnClickListener { showTrophiesSortMenu(it) }
+		panel.quickSettingsTrophiesFilterButton.setOnClickListener { showTrophiesFilterMenu(it) }
 
 		panel.quickSettingsFriendsRecyclerView.layoutManager = InstantScrollLinearLayoutManager(activity)
 		panel.quickSettingsFriendsRecyclerView.adapter = friendAdapter
@@ -728,6 +739,7 @@ class QuickSettingsPanel(
 			panel.quickSettingsMotionRow.quickSettingsRowSwitch, panel.quickSettingsHapticsRow.quickSettingsRowSwitch,
 			panel.quickSettingsPipRow.quickSettingsRowSwitch,
 			panel.quickSettingsCasSeekBarRow.quickSettingsSeekBar, panel.quickSettingsTrophiesRefreshButton,
+			panel.quickSettingsTrophiesSortButton, panel.quickSettingsTrophiesFilterButton,
 			panel.quickSettingsProcessingRow.quickSettingsDropdownSpinner, panel.quickSettingsFsrUpscalingRow.quickSettingsRowSwitch,
 			panel.quickSettingsFsrSharpeningRow.quickSettingsSeekBar,
 			panel.quickSettingsFriendsRefreshButton,
@@ -798,6 +810,7 @@ class QuickSettingsPanel(
 		panel.quickSettingsTrophiesRecyclerView.visibility = View.GONE
 		panel.quickSettingsTrophiesProgressText.visibility = View.GONE
 		panel.quickSettingsTrophiesCountsRow.visibility = View.GONE
+		panel.quickSettingsTrophiesAchievedCount.visibility = View.GONE
 
 		val gameName = viewModel.connectInfo.cloudGameName ?: ""
 		val platform = viewModel.connectInfo.cloudGamePlatform ?: ""
@@ -808,22 +821,77 @@ class QuickSettingsPanel(
 			when(result)
 			{
 				is TrophyResult.Success -> {
-					val items = buildTrophyListItems(result.detail)
-					if(items.isEmpty())
-					{
-						showTrophiesEmptyState(activity.getString(R.string.quick_settings_trophies_empty, gameName))
-					}
-					else
-					{
-						trophyAdapter.items = items
-						panel.quickSettingsTrophiesRecyclerView.visibility = View.VISIBLE
-						showTrophiesSummary(result.detail.summary)
-					}
+					currentTrophyDetail = result.detail
+					// Shown unconditionally once a detail is successfully fetched — matches
+					// TrophiesActivity's own header, which stays up even if the filtered/sorted
+					// list below it ends up empty (that's a "no matches", not "no data").
+					showTrophiesSummary(result.detail.summary)
+					renderTrophyList(gameName)
 				}
 				is TrophyResult.NoMatchFound -> showTrophiesEmptyState(activity.getString(R.string.quick_settings_trophies_empty, gameName))
 				is TrophyResult.Error -> showTrophiesEmptyState(result.message)
 			}
 		}
+	}
+
+	/** Rebuilds the trophy adapter's list from [currentTrophyDetail] under the currently selected
+	 *  sort/filter — used both by the initial load and whenever the user changes sort/filter,
+	 *  without refetching. Returns false (and shows the empty state) if the resulting list is
+	 *  empty, matching TrophiesActivity's own renderTrophyList. */
+	private fun renderTrophyList(gameName: String): Boolean
+	{
+		val detail = currentTrophyDetail ?: return false
+		val items = buildTrophyListItems(detail, trophySortMode, trophyFilterMode)
+
+		if(items.isEmpty())
+		{
+			val message = if(trophyFilterMode != TrophyFilterMode.DEFAULT)
+				activity.getString(R.string.trophy_filter_no_matches)
+			else
+				activity.getString(R.string.quick_settings_trophies_empty, gameName)
+			showTrophiesEmptyState(message)
+			return false
+		}
+
+		trophyAdapter.items = items
+		panel.quickSettingsTrophiesRecyclerView.visibility = View.VISIBLE
+		panel.quickSettingsTrophiesEmptyText.visibility = View.GONE
+		return true
+	}
+
+	private fun showTrophiesSortMenu(anchor: View)
+	{
+		val popup = PopupMenu(activity, anchor)
+		popup.menu.add(0, 0, 0, R.string.trophy_sort_default)
+		popup.menu.add(0, 1, 1, R.string.trophy_sort_earned_date)
+		popup.menu.setGroupCheckable(0, true, true)
+		popup.menu.findItem(if(trophySortMode == TrophySortMode.EARNED_DATE) 1 else 0)?.isChecked = true
+
+		popup.setOnMenuItemClickListener { item ->
+			trophySortMode = if(item.itemId == 1) TrophySortMode.EARNED_DATE else TrophySortMode.DEFAULT
+			renderTrophyList(viewModel.connectInfo.cloudGameName ?: "")
+			true
+		}
+		popup.show()
+	}
+
+	private fun showTrophiesFilterMenu(anchor: View)
+	{
+		val popup = PopupMenu(activity, anchor)
+		popup.menu.add(0, 0, 0, R.string.trophy_filter_default)
+		popup.menu.add(0, 1, 1, R.string.trophy_filter_bronze)
+		popup.menu.add(0, 2, 2, R.string.trophy_filter_silver)
+		popup.menu.add(0, 3, 3, R.string.trophy_filter_gold)
+		popup.menu.add(0, 4, 4, R.string.trophy_filter_platinum)
+		popup.menu.setGroupCheckable(0, true, true)
+		popup.menu.findItem(filterModeToItemId(trophyFilterMode))?.isChecked = true
+
+		popup.setOnMenuItemClickListener { item ->
+			trophyFilterMode = itemIdToFilterMode(item.itemId)
+			renderTrophyList(viewModel.connectInfo.cloudGameName ?: "")
+			true
+		}
+		popup.show()
 	}
 
 	private fun showTrophiesSummary(summary: TrophyTitleSummary)
@@ -834,11 +902,18 @@ class QuickSettingsPanel(
 		panel.quickSettingsTrophiesGoldCount.text = summary.earnedTrophies.gold.toString()
 		panel.quickSettingsTrophiesSilverCount.text = summary.earnedTrophies.silver.toString()
 		panel.quickSettingsTrophiesBronzeCount.text = summary.earnedTrophies.bronze.toString()
+		panel.quickSettingsTrophiesAchievedCount.text = activity.getString(
+			R.string.trophy_achieved_count_format,
+			summary.earnedTrophies.total,
+			summary.definedTrophies.total
+		)
+		panel.quickSettingsTrophiesAchievedCount.visibility = View.VISIBLE
 		panel.quickSettingsTrophiesCountsRow.visibility = View.VISIBLE
 	}
 
 	private fun showTrophiesEmptyState(message: String)
 	{
+		panel.quickSettingsTrophiesRecyclerView.visibility = View.GONE
 		panel.quickSettingsTrophiesEmptyText.text = message
 		panel.quickSettingsTrophiesEmptyText.visibility = View.VISIBLE
 	}

--- a/android/app/src/main/java/com/metallic/chiaki/trophy/TrophiesActivity.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/trophy/TrophiesActivity.kt
@@ -8,6 +8,7 @@ import android.os.Bundle
 import android.view.KeyEvent
 import android.view.View
 import android.view.WindowManager
+import android.widget.PopupMenu
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -42,6 +43,9 @@ class TrophiesActivity : AppCompatActivity()
 
 	private lateinit var binding: ActivityTrophiesBinding
 	private lateinit var repository: TrophyRepository
+	private var currentDetail: TrophyTitleDetail? = null
+	private var sortMode = TrophySortMode.DEFAULT
+	private var filterMode = TrophyFilterMode.DEFAULT
 	private val adapter = TrophyAdapter(
 		onTrophyClick = { trophy -> showTrophyDetailDialog(this, trophy) },
 		onTopBoundary = {
@@ -69,6 +73,8 @@ class TrophiesActivity : AppCompatActivity()
 
 		setSupportActionBar(binding.toolbar)
 		binding.backButton.setOnClickListener { onBackPressedDispatcher.onBackPressed() }
+		binding.trophySortButton.setOnClickListener { showSortMenu(it) }
+		binding.trophyFilterButton.setOnClickListener { showFilterMenu(it) }
 		binding.backButton.redirectDpadDownTo {
 			val firstTrophyPosition = adapter.items.indexOfFirst { it is TrophyListItem.TrophyRow }
 			if (firstTrophyPosition < 0) return@redirectDpadDownTo null
@@ -118,6 +124,7 @@ class TrophiesActivity : AppCompatActivity()
 	private fun showTrophies(detail: TrophyTitleDetail, gameName: String)
 	{
 		binding.trophyProgressBar.visibility = View.GONE
+		currentDetail = detail
 
 		val summary = detail.summary
 		binding.trophyHeaderProgress.text = "${summary.progressPercent}% Complete"
@@ -125,18 +132,75 @@ class TrophiesActivity : AppCompatActivity()
 		binding.trophyHeaderGoldCount.text = summary.earnedTrophies.gold.toString()
 		binding.trophyHeaderSilverCount.text = summary.earnedTrophies.silver.toString()
 		binding.trophyHeaderBronzeCount.text = summary.earnedTrophies.bronze.toString()
+		binding.trophyHeaderAchievedCount.text = getString(
+			R.string.trophy_achieved_count_format,
+			summary.earnedTrophies.total,
+			summary.definedTrophies.total
+		)
 
-		val items = buildTrophyListItems(detail)
+		if (!renderTrophyList(gameName)) return
+
+		binding.trophyRecyclerView.visibility = View.VISIBLE
+		focusFirstTrophy()
+	}
+
+	/** Rebuilds the adapter's list from [currentDetail] under the currently selected sort/filter —
+	 *  used both by the initial load and whenever the user changes sort/filter, without refetching.
+	 *  Returns false (and shows the empty state) if the resulting list is empty. */
+	private fun renderTrophyList(gameName: String): Boolean
+	{
+		val detail = currentDetail ?: return false
+		val items = buildTrophyListItems(detail, sortMode, filterMode)
 
 		if (items.isEmpty())
 		{
-			showEmptyState(getString(R.string.quick_settings_trophies_empty, gameName))
-			return
+			val message = if (filterMode != TrophyFilterMode.DEFAULT)
+				getString(R.string.trophy_filter_no_matches)
+			else
+				getString(R.string.quick_settings_trophies_empty, gameName)
+			showEmptyState(message)
+			return false
 		}
 
 		adapter.items = items
 		binding.trophyRecyclerView.visibility = View.VISIBLE
-		focusFirstTrophy()
+		binding.trophyEmptyStateText.visibility = View.GONE
+		return true
+	}
+
+	private fun showSortMenu(anchor: View)
+	{
+		val popup = PopupMenu(this, anchor)
+		popup.menu.add(0, 0, 0, R.string.trophy_sort_default)
+		popup.menu.add(0, 1, 1, R.string.trophy_sort_earned_date)
+		popup.menu.setGroupCheckable(0, true, true)
+		popup.menu.findItem(if (sortMode == TrophySortMode.EARNED_DATE) 1 else 0)?.isChecked = true
+
+		popup.setOnMenuItemClickListener { item ->
+			sortMode = if (item.itemId == 1) TrophySortMode.EARNED_DATE else TrophySortMode.DEFAULT
+			renderTrophyList(binding.trophyHeaderGameName.text.toString())
+			true
+		}
+		popup.show()
+	}
+
+	private fun showFilterMenu(anchor: View)
+	{
+		val popup = PopupMenu(this, anchor)
+		popup.menu.add(0, 0, 0, R.string.trophy_filter_default)
+		popup.menu.add(0, 1, 1, R.string.trophy_filter_bronze)
+		popup.menu.add(0, 2, 2, R.string.trophy_filter_silver)
+		popup.menu.add(0, 3, 3, R.string.trophy_filter_gold)
+		popup.menu.add(0, 4, 4, R.string.trophy_filter_platinum)
+		popup.menu.setGroupCheckable(0, true, true)
+		popup.menu.findItem(filterModeToItemId(filterMode))?.isChecked = true
+
+		popup.setOnMenuItemClickListener { item ->
+			filterMode = itemIdToFilterMode(item.itemId)
+			renderTrophyList(binding.trophyHeaderGameName.text.toString())
+			true
+		}
+		popup.show()
 	}
 
 	/** Lands D-pad/keyboard focus on the first trophy row (skipping group headers, which aren't

--- a/android/app/src/main/java/com/metallic/chiaki/trophy/TrophyAdapter.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/trophy/TrophyAdapter.kt
@@ -30,14 +30,63 @@ sealed class TrophyListItem
 	data class TrophyRow(val trophy: Trophy) : TrophyListItem()
 }
 
-/** Shared by [TrophiesActivity] and [QuickSettingsPanel]'s in-stream Trophies tab so both
- *  present identical group-header + trophy-row structure from the same fetched detail. */
-fun buildTrophyListItems(detail: TrophyTitleDetail): List<TrophyListItem>
+/** "Default" restores the game's own group ordering; "Earned Date" flattens everything (group
+ *  headers stop making sense once trophies are reordered across groups) and pulls every unlocked
+ *  trophy to the top, most recent first, with locked trophies left after in their original order. */
+enum class TrophySortMode { DEFAULT, EARNED_DATE }
+
+/** "Default" shows every trophy; the rest restrict the list to just that rarity. */
+enum class TrophyFilterMode { DEFAULT, BRONZE, SILVER, GOLD, PLATINUM }
+
+/** Shared PopupMenu item-id <-> [TrophyFilterMode] mapping so [TrophiesActivity] and
+ *  [com.metallic.chiaki.stream.QuickSettingsPanel]'s filter menus stay in sync. */
+fun filterModeToItemId(mode: TrophyFilterMode): Int = when (mode)
 {
+	TrophyFilterMode.DEFAULT -> 0
+	TrophyFilterMode.BRONZE -> 1
+	TrophyFilterMode.SILVER -> 2
+	TrophyFilterMode.GOLD -> 3
+	TrophyFilterMode.PLATINUM -> 4
+}
+
+fun itemIdToFilterMode(itemId: Int): TrophyFilterMode = when (itemId)
+{
+	1 -> TrophyFilterMode.BRONZE
+	2 -> TrophyFilterMode.SILVER
+	3 -> TrophyFilterMode.GOLD
+	4 -> TrophyFilterMode.PLATINUM
+	else -> TrophyFilterMode.DEFAULT
+}
+
+/** Shared by [TrophiesActivity] and [QuickSettingsPanel]'s in-stream Trophies tab so both
+ *  present identical group-header + trophy-row structure from the same fetched detail, under
+ *  whichever sort/filter the user currently has selected. */
+fun buildTrophyListItems(
+	detail: TrophyTitleDetail,
+	sortMode: TrophySortMode = TrophySortMode.DEFAULT,
+	filterMode: TrophyFilterMode = TrophyFilterMode.DEFAULT
+): List<TrophyListItem>
+{
+	val trophies = when (filterMode)
+	{
+		TrophyFilterMode.DEFAULT -> detail.trophies
+		TrophyFilterMode.BRONZE -> detail.trophies.filter { it.type == TrophyType.BRONZE }
+		TrophyFilterMode.SILVER -> detail.trophies.filter { it.type == TrophyType.SILVER }
+		TrophyFilterMode.GOLD -> detail.trophies.filter { it.type == TrophyType.GOLD }
+		TrophyFilterMode.PLATINUM -> detail.trophies.filter { it.type == TrophyType.PLATINUM }
+	}
+
+	if (sortMode == TrophySortMode.EARNED_DATE)
+	{
+		val (earned, locked) = trophies.partition { it.earned }
+		val orderedEarned = earned.sortedByDescending { it.earnedDateTimeMs ?: Long.MIN_VALUE }
+		return (orderedEarned + locked).map { TrophyListItem.TrophyRow(it) }
+	}
+
 	val items = mutableListOf<TrophyListItem>()
 	if (detail.groups.isEmpty())
 	{
-		detail.trophies.forEach { items.add(TrophyListItem.TrophyRow(it)) }
+		trophies.forEach { items.add(TrophyListItem.TrophyRow(it)) }
 	}
 	else
 	{
@@ -45,8 +94,14 @@ fun buildTrophyListItems(detail: TrophyTitleDetail): List<TrophyListItem>
 		// just the base game group), all of which fall back to the generic "Trophies" label
 		// below — only the first such fallback gets its own header so it doesn't repeat further
 		// down the list; later empty-named groups' trophies fold under that same header.
+		// A group filtered down to zero trophies is skipped entirely rather than left as a
+		// header with nothing under it — but only once a filter is active, so the unfiltered
+		// "Default" view's group structure is untouched from before filtering existed.
 		var fallbackHeaderShown = false
 		detail.groups.forEach { group ->
+			val groupTrophies = trophies.filter { it.groupId == group.groupId }
+			if (filterMode != TrophyFilterMode.DEFAULT && groupTrophies.isEmpty()) return@forEach
+
 			if (group.groupName.isNotEmpty())
 			{
 				items.add(TrophyListItem.GroupHeader(group.groupName))
@@ -56,8 +111,7 @@ fun buildTrophyListItems(detail: TrophyTitleDetail): List<TrophyListItem>
 				items.add(TrophyListItem.GroupHeader("Trophies"))
 				fallbackHeaderShown = true
 			}
-			detail.trophies.filter { it.groupId == group.groupId }
-				.forEach { items.add(TrophyListItem.TrophyRow(it)) }
+			groupTrophies.forEach { items.add(TrophyListItem.TrophyRow(it)) }
 		}
 	}
 	return items

--- a/android/app/src/main/res/drawable/ic_filter.xml
+++ b/android/app/src/main/res/drawable/ic_filter.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M10,18h4v-2h-4v2zM3,6v2h18L21,6L3,6zM6,13h12v-2L6,11v2z"/>
+</vector>

--- a/android/app/src/main/res/layout/activity_trophies.xml
+++ b/android/app/src/main/res/layout/activity_trophies.xml
@@ -22,7 +22,7 @@
                 android:layout_gravity="center_vertical"
                 android:gravity="center"
                 android:paddingStart="56dp"
-                android:paddingEnd="56dp"
+                android:paddingEnd="104dp"
                 android:maxLines="1"
                 android:ellipsize="end"
                 android:fontFamily="sans-serif-condensed"
@@ -42,6 +42,38 @@
                 android:contentDescription="@string/action_back"
                 android:src="@drawable/ic_arrow_back"
                 android:tint="?attr/colorOnPrimary"/>
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end|center_vertical"
+                android:orientation="horizontal">
+
+                <ImageButton
+                    android:id="@+id/trophySortButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:padding="12dp"
+                    android:background="?attr/selectableItemBackgroundBorderless"
+                    android:foreground="@drawable/bg_focus_highlight"
+                    android:focusable="true"
+                    android:contentDescription="@string/trophy_sort_content_description"
+                    android:src="@drawable/ic_sort"
+                    android:tint="?attr/colorOnPrimary"/>
+
+                <ImageButton
+                    android:id="@+id/trophyFilterButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:padding="12dp"
+                    android:background="?attr/selectableItemBackgroundBorderless"
+                    android:foreground="@drawable/bg_focus_highlight"
+                    android:focusable="true"
+                    android:contentDescription="@string/trophy_filter_content_description"
+                    android:src="@drawable/ic_filter"
+                    android:tint="?attr/colorOnPrimary"/>
+
+            </LinearLayout>
         </FrameLayout>
     </com.google.android.material.appbar.MaterialToolbar>
 
@@ -95,7 +127,7 @@
                 android:textSize="13sp" />
 
             <LinearLayout
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="6dp"
                 android:orientation="horizontal">
@@ -119,6 +151,18 @@
                     android:id="@+id/trophyHeaderBronzeCount"
                     style="@style/TrophyHeaderCount"
                     android:background="@drawable/bg_trophy_bronze" />
+
+                <TextView
+                    android:id="@+id/trophyHeaderAchievedCount"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_gravity="center_vertical"
+                    android:layout_marginStart="4dp"
+                    android:maxLines="1"
+                    android:ellipsize="end"
+                    android:textColor="@android:color/white"
+                    android:textSize="12sp" />
 
             </LinearLayout>
 

--- a/android/app/src/main/res/layout/stream_quick_settings_panel.xml
+++ b/android/app/src/main/res/layout/stream_quick_settings_panel.xml
@@ -428,7 +428,7 @@
             android:text="@string/quick_settings_trophies_header_label"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/quickSettingsTrophiesRefreshButton" />
+            app:layout_constraintEnd_toStartOf="@id/quickSettingsTrophiesFilterButton" />
 
         <ImageButton
             android:id="@+id/quickSettingsTrophiesRefreshButton"
@@ -442,6 +442,32 @@
             app:layout_constraintTop_toTopOf="@id/quickSettingsTrophiesLabel"
             app:layout_constraintBottom_toBottomOf="@id/quickSettingsTrophiesLabel"
             app:layout_constraintEnd_toEndOf="parent" />
+
+        <ImageButton
+            android:id="@+id/quickSettingsTrophiesFilterButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="4dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/trophy_filter_content_description"
+            android:src="@drawable/ic_filter"
+            android:tint="?attr/pyluxAccent"
+            app:layout_constraintTop_toTopOf="@id/quickSettingsTrophiesLabel"
+            app:layout_constraintBottom_toBottomOf="@id/quickSettingsTrophiesLabel"
+            app:layout_constraintEnd_toStartOf="@id/quickSettingsTrophiesSortButton" />
+
+        <ImageButton
+            android:id="@+id/quickSettingsTrophiesSortButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="4dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/trophy_sort_content_description"
+            android:src="@drawable/ic_sort"
+            android:tint="?attr/pyluxAccent"
+            app:layout_constraintTop_toTopOf="@id/quickSettingsTrophiesLabel"
+            app:layout_constraintBottom_toBottomOf="@id/quickSettingsTrophiesLabel"
+            app:layout_constraintEnd_toStartOf="@id/quickSettingsTrophiesRefreshButton" />
 
         <!-- Completion summary — mirrors TrophiesActivity's own header styling (same
              TrophyHeaderCount badges). Only shown alongside a successfully loaded list, so it
@@ -464,14 +490,16 @@
 
         <LinearLayout
             android:id="@+id/quickSettingsTrophiesCountsRow"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="6dp"
             android:paddingStart="16dp"
+            android:paddingEnd="16dp"
             android:orientation="horizontal"
             android:visibility="gone"
             app:layout_constraintTop_toBottomOf="@id/quickSettingsTrophiesProgressText"
-            app:layout_constraintStart_toStartOf="parent">
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent">
 
             <TextView
                 android:id="@+id/quickSettingsTrophiesPlatinumCount"
@@ -494,6 +522,25 @@
                 android:background="@drawable/bg_trophy_bronze" />
 
         </LinearLayout>
+
+        <!-- On its own line rather than crammed to the right of the bronze badge — the panel is
+             only 320dp wide with four badges already eating most of that, so sharing a row left
+             "X/Y Trophies Achieved" ellipsized down to almost nothing. -->
+        <TextView
+            android:id="@+id/quickSettingsTrophiesAchievedCount"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:maxLines="1"
+            android:ellipsize="end"
+            android:textColor="@android:color/white"
+            android:textSize="11sp"
+            android:visibility="gone"
+            app:layout_constraintTop_toBottomOf="@id/quickSettingsTrophiesCountsRow"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
 
         <ProgressBar
             android:id="@+id/quickSettingsTrophiesProgressBar"
@@ -527,7 +574,7 @@
             android:visibility="gone"
             android:clipToPadding="false"
             android:paddingBottom="16dp"
-            app:layout_constraintTop_toBottomOf="@id/quickSettingsTrophiesCountsRow"
+            app:layout_constraintTop_toBottomOf="@id/quickSettingsTrophiesAchievedCount"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -250,6 +250,17 @@
     <string name="quick_settings_trophies_refresh">Refresh trophies</string>
     <string name="quick_settings_trophies_empty">No trophy data could be retrieved for %1$s, please launch the game and allow the trophy data to be synched.\n\nThis can take around 5-10 minutes during a session. Then you can refresh the trophy list and the trophy data should appear.\n\nIf the trophy data is still missing, please raise an issue on the CloudPad github repository to be looked into</string>
     <string name="trophy_unlock_popup_header">Trophy unlocked!</string>
+    <string name="trophy_achieved_count_format">%1$d/%2$d Trophies Achieved</string>
+    <string name="trophy_sort_content_description">Sort trophies</string>
+    <string name="trophy_filter_content_description">Filter trophies</string>
+    <string name="trophy_sort_default">Default</string>
+    <string name="trophy_sort_earned_date">Earned Date</string>
+    <string name="trophy_filter_default">Default</string>
+    <string name="trophy_filter_bronze">Bronze</string>
+    <string name="trophy_filter_silver">Silver</string>
+    <string name="trophy_filter_gold">Gold</string>
+    <string name="trophy_filter_platinum">Platinum</string>
+    <string name="trophy_filter_no_matches">No trophies match this filter.</string>
     <string name="action_friends">Friends</string>
     <string name="friends_empty_state">No friends found on this PSN account.</string>
     <string name="friend_chat_empty_state">No messages yet — say hi!</string>

--- a/android/app/src/test/java/com/metallic/chiaki/trophy/TrophyAdapterTest.kt
+++ b/android/app/src/test/java/com/metallic/chiaki/trophy/TrophyAdapterTest.kt
@@ -19,16 +19,22 @@ class TrophyAdapterTest {
         earnedTrophies = TrophyCounts()
     )
 
-    private fun trophy(id: Int, groupId: String) = Trophy(
+    private fun trophy(
+        id: Int,
+        groupId: String,
+        type: TrophyType = TrophyType.BRONZE,
+        earned: Boolean = false,
+        earnedDateTimeMs: Long? = null
+    ) = Trophy(
         trophyId = id,
         groupId = groupId,
-        type = TrophyType.BRONZE,
+        type = type,
         name = "Trophy $id",
         detail = "",
         iconUrl = "",
         hidden = false,
-        earned = false,
-        earnedDateTimeMs = null
+        earned = earned,
+        earnedDateTimeMs = earnedDateTimeMs
     )
 
     private fun detail(groups: List<TrophyGroup>, trophies: List<Trophy>) = TrophyTitleDetail(
@@ -89,5 +95,78 @@ class TrophyAdapterTest {
 
         assertEquals(0, items.filterIsInstance<TrophyListItem.GroupHeader>().size)
         assertEquals(1, items.filterIsInstance<TrophyListItem.TrophyRow>().size)
+    }
+
+    @Test
+    fun `earned date sort flattens headers, puts unlocked trophies first by most recent`() {
+        val groups = listOf(group("default", "My Game"))
+        val trophies = listOf(
+            trophy(1, "default", earned = true, earnedDateTimeMs = 1000L),
+            trophy(2, "default", earned = false),
+            trophy(3, "default", earned = true, earnedDateTimeMs = 3000L),
+            trophy(4, "default", earned = false)
+        )
+
+        val items = buildTrophyListItems(detail(groups, trophies), sortMode = TrophySortMode.EARNED_DATE)
+
+        assertEquals(0, items.filterIsInstance<TrophyListItem.GroupHeader>().size)
+        val order = items.filterIsInstance<TrophyListItem.TrophyRow>().map { it.trophy.trophyId }
+        assertEquals(listOf(3, 1, 2, 4), order)
+    }
+
+    @Test
+    fun `default sort with earned date mode selected but no groups still flattens`() {
+        val trophies = listOf(
+            trophy(1, "default", earned = true, earnedDateTimeMs = 500L),
+            trophy(2, "default", earned = true, earnedDateTimeMs = 1500L)
+        )
+
+        val items = buildTrophyListItems(detail(emptyList(), trophies), sortMode = TrophySortMode.EARNED_DATE)
+
+        val order = items.filterIsInstance<TrophyListItem.TrophyRow>().map { it.trophy.trophyId }
+        assertEquals(listOf(2, 1), order)
+    }
+
+    @Test
+    fun `filtering by rarity keeps only that rarity's trophies`() {
+        val groups = listOf(group("default", "My Game"))
+        val trophies = listOf(
+            trophy(1, "default", type = TrophyType.BRONZE),
+            trophy(2, "default", type = TrophyType.GOLD),
+            trophy(3, "default", type = TrophyType.GOLD),
+            trophy(4, "default", type = TrophyType.PLATINUM)
+        )
+
+        val items = buildTrophyListItems(detail(groups, trophies), filterMode = TrophyFilterMode.GOLD)
+
+        val order = items.filterIsInstance<TrophyListItem.TrophyRow>().map { it.trophy.trophyId }
+        assertEquals(listOf(2, 3), order)
+    }
+
+    @Test
+    fun `filtering to a rarity with no matches in a group skips that group's header`() {
+        val groups = listOf(group("default", ""), group("001", "Expansion Pack"))
+        val trophies = listOf(
+            trophy(1, "default", type = TrophyType.BRONZE),
+            trophy(2, "001", type = TrophyType.SILVER)
+        )
+
+        val items = buildTrophyListItems(detail(groups, trophies), filterMode = TrophyFilterMode.SILVER)
+
+        val headers = items.filterIsInstance<TrophyListItem.GroupHeader>()
+        assertEquals(listOf("Expansion Pack"), headers.map { it.name })
+        assertEquals(listOf(2), items.filterIsInstance<TrophyListItem.TrophyRow>().map { it.trophy.trophyId })
+    }
+
+    @Test
+    fun `default filter mode is unaffected by empty-group skipping`() {
+        val groups = listOf(group("default", ""), group("001", ""), group("002", ""))
+        val trophies = listOf(trophy(1, "default"), trophy(2, "001"), trophy(3, "002"))
+
+        val items = buildTrophyListItems(detail(groups, trophies), filterMode = TrophyFilterMode.DEFAULT)
+
+        val headers = items.filterIsInstance<TrophyListItem.GroupHeader>()
+        assertEquals(listOf("Trophies"), headers.map { it.name })
+        assertEquals(3, items.filterIsInstance<TrophyListItem.TrophyRow>().size)
     }
 }


### PR DESCRIPTION
Trophies screen and the in-stream Trophies quick menu now show an X/Y achieved count next to the badges, and let the user sort by earned date (unlocked first, most recent on top) or filter down to a single rarity, both defaulting back to the original view.