### PR TITLE
Show a Log In row in Settings when signed out

### DIFF
--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RELEASE_NOTES: >-
-        Added a trophies-achieved counter, sort by earned date, and rarity filtering to the Trophies screen and the in-stream Trophies quick menu.
+        Settings now shows a Log In row (instead of hiding it) once signed out, and fixed a crash on logout that was kicking users back to the main screen.
 
     steps:
       - name: Checkout repo

--- a/android/app/src/main/java/com/metallic/chiaki/settings/SettingsFragment.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/settings/SettingsFragment.kt
@@ -15,6 +15,7 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.preference.*
+import com.metallic.chiaki.cloudplay.PsnLoginActivity
 import com.metallic.chiaki.common.ext.alertDialogBuilder
 import com.pylux.stream.BuildConfig
 import com.pylux.stream.R
@@ -147,6 +148,19 @@ class SettingsFragment: PreferenceFragmentCompat(), TitleFragment
 
 	// Must be registered before the Fragment reaches STARTED, so this is a property initializer
 	// rather than something set up inside onCreatePreferences.
+	// Must be registered before the Fragment reaches STARTED, same reasoning as
+	// micPermissionLauncher below — refreshes the Account row's title/summary either way, since a
+	// cancelled/failed login still needs to keep the row saying "Log In" rather than freeze on
+	// leftover progress state.
+	private val psnLoginLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+		if(result.resultCode == Activity.RESULT_OK)
+		{
+			Toast.makeText(requireContext(), R.string.psn_login_success, Toast.LENGTH_SHORT).show()
+		}
+		updatePsnAccountPreference()
+		updateLocalePreference()
+	}
+
 	private val micPermissionLauncher = registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
 		val micPreference = preferenceScreen?.findPreference<SwitchPreference>(getString(R.string.preferences_microphone_enabled_key))
 		if(granted)
@@ -294,23 +308,8 @@ class SettingsFragment: PreferenceFragmentCompat(), TitleFragment
 		preferenceScreen.findPreference<Preference>(getString(R.string.preferences_export_settings_key))?.setOnPreferenceClickListener { exportSettings(); true }
 		preferenceScreen.findPreference<Preference>(getString(R.string.preferences_import_settings_key))?.setOnPreferenceClickListener { importSettings(); true }
 
-		val logoutPreference = preferenceScreen.findPreference<Preference>("psn_logout")
-		logoutPreference?.isVisible = preferences.hasNpssoToken()
-		logoutPreference?.setOnPreferenceClickListener { showLogoutConfirmation(preferences); true }
-
-		val localePreference = preferenceScreen.findPreference<ListPreference>("locale_display")
-		if (preferences.hasNpssoToken())
-		{
-			localePreference?.entries = CLOUD_LOCALES.map { "${it.second} (${it.first})" }.toTypedArray()
-			localePreference?.entryValues = CLOUD_LOCALES.map { it.first }.toTypedArray()
-			localePreference?.value = preferences.getCloudStoreLocale()
-			localePreference?.summaryProvider = ListPreference.SimpleSummaryProvider.getInstance()
-		}
-		else
-		{
-			localePreference?.isEnabled = false
-			localePreference?.summary = getString(R.string.preferences_locale_summary_not_set)
-		}
+		updatePsnAccountPreference()
+		updateLocalePreference()
 
 		val cachedLocalePreference = preferenceScreen.findPreference<Preference>("cached_locale_display")
 		val rawStored = preferences.getRawStoredLocale()
@@ -377,6 +376,60 @@ class SettingsFragment: PreferenceFragmentCompat(), TitleFragment
 		startActivity(intent)
 	}
 
+	/** Single "Account" row that flips between "Log Out" (tap to confirm sign-out) and "Log In"
+	 *  (tap to launch [PsnLoginActivity]) depending on [Preferences.hasNpssoToken] — re-called
+	 *  after logout and after the login activity returns so the row always reflects current
+	 *  state rather than needing the settings screen reopened. */
+	private fun updatePsnAccountPreference()
+	{
+		val preference = preferenceScreen?.findPreference<Preference>("psn_account") ?: return
+		val preferences = Preferences(requireContext())
+
+		if(preferences.hasNpssoToken())
+		{
+			preference.title = getString(R.string.preferences_psn_logout_title)
+			preference.summary = getString(R.string.preferences_psn_login_summary_logged_in)
+			preference.setIcon(R.drawable.ic_close_white)
+			preference.setOnPreferenceClickListener { showLogoutConfirmation(preferences); true }
+		}
+		else
+		{
+			preference.title = getString(R.string.preferences_psn_login_row_title)
+			preference.summary = getString(R.string.preferences_psn_login_row_summary)
+			preference.setIcon(R.drawable.ic_psn_id_white)
+			preference.setOnPreferenceClickListener {
+				psnLoginLauncher.launch(Intent(requireContext(), PsnLoginActivity::class.java))
+				true
+			}
+		}
+	}
+
+	/** Cloud store locale only makes sense once logged in — re-called alongside
+	 *  [updatePsnAccountPreference] so it flips enabled/disabled in step with the account row
+	 *  rather than only being correct the next time Settings is freshly opened. */
+	private fun updateLocalePreference()
+	{
+		val preferences = Preferences(requireContext())
+		val localePreference = preferenceScreen?.findPreference<ListPreference>("locale_display") ?: return
+		if (preferences.hasNpssoToken())
+		{
+			localePreference.entries = CLOUD_LOCALES.map { "${it.second} (${it.first})" }.toTypedArray()
+			localePreference.entryValues = CLOUD_LOCALES.map { it.first }.toTypedArray()
+			localePreference.value = preferences.getCloudStoreLocale()
+			localePreference.summaryProvider = ListPreference.SimpleSummaryProvider.getInstance()
+			localePreference.isEnabled = true
+		}
+		else
+		{
+			// The logged-in branch above sets a SummaryProvider, which Preference.setSummary()
+			// refuses to run alongside once set — has to be cleared first or this throws
+			// IllegalStateException the moment a user logs out with the locale already loaded.
+			localePreference.summaryProvider = null
+			localePreference.isEnabled = false
+			localePreference.summary = getString(R.string.preferences_locale_summary_not_set)
+		}
+	}
+
 	private fun showLogoutConfirmation(preferences: Preferences)
 	{
 		requireContext().alertDialogBuilder()
@@ -396,7 +449,8 @@ class SettingsFragment: PreferenceFragmentCompat(), TitleFragment
 		preferences.psnRefreshToken = ""
 		preferences.psnAuthTokenExpiry = 0L
 		preferences.psnAccountId = ""
-		preferenceScreen?.findPreference<Preference>("psn_logout")?.isVisible = false
+		updatePsnAccountPreference()
+		updateLocalePreference()
 		Toast.makeText(requireContext(), R.string.preferences_psn_logout_success, Toast.LENGTH_SHORT).show()
 	}
 

--- a/android/app/src/main/res/drawable/ic_psn_id_white.xml
+++ b/android/app/src/main/res/drawable/ic_psn_id_white.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,12c2.21,0 4,-1.79 4,-4s-1.79,-4 -4,-4 -4,1.79 -4,4 1.79,4 4,4zM12,14c-2.67,0 -8,1.34 -8,4v2h16v-2c0,-2.66 -5.33,-4 -8,-4z"/>
+</vector>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -307,6 +307,8 @@
     <string name="preferences_psn_logout_message">Are you sure you want to logout?</string>
     <string name="preferences_psn_logout_confirm">Logout</string>
     <string name="preferences_psn_logout_success">Logged out successfully</string>
+    <string name="preferences_psn_login_row_title">Log In</string>
+    <string name="preferences_psn_login_row_summary">Tap to sign in</string>
     <string name="preferences_locale_title">Locale</string>
     <string name="preferences_locale_summary_not_set">Not set - Please sign in to obtain locale</string>
     <string name="preferences_cached_locale_title">Cached Locale</string>

--- a/android/app/src/main/res/xml/preferences.xml
+++ b/android/app/src/main/res/xml/preferences.xml
@@ -44,10 +44,10 @@
             app:icon="@drawable/ic_console_simple"/>
 
         <Preference
-            app:key="psn_logout"
-            app:title="@string/preferences_psn_logout_title"
-            app:summary="@string/preferences_psn_login_summary_logged_in"
-            app:icon="@drawable/ic_close_white"/>
+            app:key="psn_account"
+            app:title="@string/preferences_psn_login_row_title"
+            app:summary="@string/preferences_psn_login_row_summary"
+            app:icon="@drawable/ic_psn_id_white"/>
 
         <ListPreference
             app:key="locale_display"


### PR DESCRIPTION
The account row used to disappear entirely once logged out, leaving no way back in from Settings. It now flips between "Log Out"/"Tap to sign out" and "Log In"/"Tap to sign in", launching PsnLoginActivity in the latter case, with a white icon matching the row's other icons.

Also fixes a crash on logout: the locale preference set a SummaryProvider while logged in, then tried to set a plain summary string on top of it while logged out without clearing that provider first, which androidx.preference throws on — the crash was killing SettingsActivity and revealing MainActivity underneath, which looked like being kicked to the main screen.