### PR TITLE
Add profile status icon, fix pop-up styling and rotation bugs

### DIFF
--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RELEASE_NOTES: >-
-        Settings now shows a Log In row (instead of hiding it) once signed out, and fixed a crash on logout that was kicking users back to the main screen.
+        Added a profile icon with a live online/busy/offline status dot next to Friends on the main screen; fixed every unstyled pop-up/dropdown in the app (Settings preferences, Quick Menu dropdowns, the controller remap overflow menu, the game-launch splash screen) to match the app's themed grey-and-accent-border look; fixed a Settings crash and a lost logout dialog when rotating the device; and fixed the header logo overlapping the top-bar icons in portrait.
 
     steps:
       - name: Checkout repo

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -58,7 +58,8 @@
 
         <activity
             android:name="com.metallic.chiaki.settings.SettingsActivity"
-            android:exported="false" />
+            android:exported="false"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenSize" />
 
         <activity
             android:name="com.metallic.chiaki.trophy.TrophiesActivity"

--- a/android/app/src/main/java/com/metallic/chiaki/common/Preferences.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/common/Preferences.kt
@@ -309,6 +309,7 @@ class Preferences(context: Context)
 	private val PSN_AUTH_TOKEN_EXPIRY_KEY = "psn_rp_auth_token_expiry"
 	private val PSN_ACCOUNT_ID_KEY = "psn_rp_account_id"
 	private val PSN_DUID_KEY = "psn_rp_duid"
+	private val PSN_AVATAR_URL_KEY = "psn_avatar_url"
 
 	var psnAuthToken: String
 		get() = sharedPreferences.getString(PSN_AUTH_TOKEN_KEY, "") ?: ""
@@ -331,6 +332,13 @@ class Preferences(context: Context)
 	var psnDuid: String
 		get() = sharedPreferences.getString(PSN_DUID_KEY, "") ?: ""
 		set(value) { sharedPreferences.edit().putString(PSN_DUID_KEY, value).apply() }
+
+	/** Cached signed-in profile picture URL, shown as the main screen's account icon — fetched
+	 *  lazily (see MainActivity) rather than at login time, so login itself doesn't grow another
+	 *  network dependency; empty until that first fetch succeeds. */
+	var psnAvatarUrl: String
+		get() = sharedPreferences.getString(PSN_AVATAR_URL_KEY, "") ?: ""
+		set(value) { sharedPreferences.edit().putString(PSN_AVATAR_URL_KEY, value).apply() }
 
 	val hasPsnRemotePlayTokens: Boolean
 		get() = psnAuthToken.isNotEmpty() && psnRefreshToken.isNotEmpty()

--- a/android/app/src/main/java/com/metallic/chiaki/common/ext/DialogUtils.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/common/ext/DialogUtils.kt
@@ -9,8 +9,10 @@ import android.graphics.drawable.ColorDrawable
 import android.util.TypedValue
 import android.view.KeyEvent
 import android.widget.TextView
+import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.metallic.chiaki.common.Preferences
 import com.pylux.stream.R
 
 private const val TV_TITLE_SP = 28f
@@ -96,3 +98,25 @@ class AppAlertDialogBuilder(context: Context) : MaterialAlertDialogBuilder(conte
  * `context.alertDialogBuilder()` so TV enhancements are applied automatically.
  */
 fun Context.alertDialogBuilder(): AppAlertDialogBuilder = AppAlertDialogBuilder(this)
+
+/** Single shared "are you sure you want to log out" flow — originally only reachable from
+ *  Settings, now also triggered from the main screen's account icon dropdown. Both callers get
+ *  identical copy and identical state clearing this way, rather than two copies drifting apart. */
+fun Context.showPsnLogoutConfirmation(preferences: Preferences, onLoggedOut: () -> Unit = {})
+{
+	alertDialogBuilder()
+		.setTitle(R.string.preferences_psn_logout_title)
+		.setMessage(R.string.preferences_psn_logout_message)
+		.setPositiveButton(R.string.preferences_psn_logout_confirm) { _, _ ->
+			preferences.clearNpssoToken()
+			preferences.psnAuthToken = ""
+			preferences.psnRefreshToken = ""
+			preferences.psnAuthTokenExpiry = 0L
+			preferences.psnAccountId = ""
+			preferences.psnAvatarUrl = ""
+			Toast.makeText(this, R.string.preferences_psn_logout_success, Toast.LENGTH_SHORT).show()
+			onLoggedOut()
+		}
+		.setNegativeButton(R.string.action_cancel, null)
+		.show()
+}

--- a/android/app/src/main/java/com/metallic/chiaki/friends/FriendAdapter.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/friends/FriendAdapter.kt
@@ -35,6 +35,7 @@ class FriendAdapter(
 	companion object
 	{
 		private const val ONLINE_COLOR = 0xFF4CAF50.toInt()
+		private const val BUSY_COLOR = 0xFFFFC107.toInt()
 		private const val OFFLINE_COLOR = 0xFFB3B3B3.toInt()
 	}
 
@@ -173,15 +174,28 @@ class FriendAdapter(
 			binding.friendItemStatus.text = when
 			{
 				friend.currentGame.isNotEmpty() -> "Playing ${friend.currentGame}"
+				friend.isBusy -> "Busy"
 				friend.isOnline -> "Online"
 				friend.lastOnlineDateMs != null -> "Last online " + DateUtils.getRelativeTimeSpanString(
 					friend.lastOnlineDateMs, System.currentTimeMillis(), DateUtils.MINUTE_IN_MILLIS
 				)
 				else -> "Offline"
 			}
-			binding.friendItemStatus.setTextColor(if (friend.isOnline) ONLINE_COLOR else OFFLINE_COLOR)
+			binding.friendItemStatus.setTextColor(
+				when
+				{
+					friend.isBusy -> BUSY_COLOR
+					friend.isOnline -> ONLINE_COLOR
+					else -> OFFLINE_COLOR
+				}
+			)
 			binding.friendItemStatusDot.setBackgroundResource(
-				if (friend.isOnline) R.drawable.bg_friend_online_dot else R.drawable.bg_friend_offline_dot
+				when
+				{
+					friend.isBusy -> R.drawable.bg_friend_busy_dot
+					friend.isOnline -> R.drawable.bg_friend_online_dot
+					else -> R.drawable.bg_friend_offline_dot
+				}
 			)
 
 			if (friend.avatarUrl.isNotEmpty())

--- a/android/app/src/main/java/com/metallic/chiaki/friends/FriendModels.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/friends/FriendModels.kt
@@ -7,6 +7,9 @@ data class Friend(
 	val onlineId: String,
 	val avatarUrl: String,
 	val isOnline: Boolean,
+	/** Separate from [isOnline] — Sony's own "Busy" PS App status, distinct from being connected
+	 *  at all (see FriendsService.PresenceInfo). */
+	val isBusy: Boolean,
 	val currentGame: String,
 	/** Epoch millis, or null if never reported — formatted relative-to-now at display time
 	 *  (see FriendAdapter), same as how TrophyAdapter formats a trophy's earnedDateTimeMs. */

--- a/android/app/src/main/java/com/metallic/chiaki/friends/FriendsRepository.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/friends/FriendsRepository.kt
@@ -65,6 +65,7 @@ class FriendsRepository(private val preferences: Preferences)
 					onlineId = onlineId,
 					avatarUrl = avatarUrl,
 					isOnline = presence?.isOnline ?: false,
+					isBusy = presence?.isBusy ?: false,
 					currentGame = presence?.currentGame ?: "",
 					lastOnlineDateMs = presence?.lastOnlineDateMs
 				)

--- a/android/app/src/main/java/com/metallic/chiaki/friends/FriendsService.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/friends/FriendsService.kt
@@ -72,7 +72,10 @@ object FriendsService
 		return onlineId to avatarUrl
 	}
 
-	data class PresenceInfo(val isOnline: Boolean, val currentGame: String, val lastOnlineDateMs: Long?)
+	/** [isBusy] is a separate top-level `availability` field Sony sends alongside
+	 *  `primaryPlatformInfo.onlineStatus` — live-tested: onlineStatus stays "online" when the
+	 *  account sets itself to Busy in the PS App, so isOnline alone can't distinguish them. */
+	data class PresenceInfo(val isOnline: Boolean, val isBusy: Boolean, val currentGame: String, val lastOnlineDateMs: Long?)
 
 	/** Presence for every id in [accountIds], batched into a single call. */
 	suspend fun fetchPresences(accessToken: String, accountIds: List<String>): Map<String, PresenceInfo>
@@ -108,13 +111,16 @@ object FriendsService
 
 			val primary = obj.optJSONObject("primaryPlatformInfo")
 			val isOnline = primary?.optString("onlineStatus", "offline") == "online"
+			// Top-level, not under primaryPlatformInfo — confirmed against a live "Busy" account:
+			// {"accountId":"...","availability":"busy","primaryPlatformInfo":{"onlineStatus":"online",...}}
+			val isBusy = obj.optString("availability", "") == "busy"
 			val titles = obj.optJSONArray("gameTitleInfoList")
 			val titleName = if (titles != null && titles.length() > 0) titles.getJSONObject(0).optString("titleName", "") else ""
 			// primaryPlatformInfo.lastOnlineDate is the per-platform figure; lastAvailableDate is
 			// the top-level fallback Sony sends when there's no primaryPlatformInfo at all.
 			val lastOnlineDate = primary?.optString("lastOnlineDate", "")?.ifEmpty { null }
 				?: obj.optString("lastAvailableDate", "").ifEmpty { null }
-			result[accountId] = PresenceInfo(isOnline, titleName, lastOnlineDate?.let { parseIsoTimestamp(it) })
+			result[accountId] = PresenceInfo(isOnline, isBusy, titleName, lastOnlineDate?.let { parseIsoTimestamp(it) })
 		}
 		return result
 	}
@@ -260,6 +266,7 @@ object FriendsService
 				put("onlineId", f.onlineId)
 				put("avatarUrl", f.avatarUrl)
 				put("isOnline", f.isOnline)
+				put("isBusy", f.isBusy)
 				put("currentGame", f.currentGame)
 				put("lastOnlineDateMs", f.lastOnlineDateMs ?: -1L)
 			})
@@ -281,6 +288,7 @@ object FriendsService
 					onlineId = obj.optString("onlineId", ""),
 					avatarUrl = obj.optString("avatarUrl", ""),
 					isOnline = obj.optBoolean("isOnline", false),
+					isBusy = obj.optBoolean("isBusy", false),
 					currentGame = obj.optString("currentGame", ""),
 					lastOnlineDateMs = if (lastOnline >= 0) lastOnline else null
 				)

--- a/android/app/src/main/java/com/metallic/chiaki/main/MainActivity.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/main/MainActivity.kt
@@ -5,6 +5,7 @@ package com.metallic.chiaki.main
 import com.metallic.chiaki.common.ext.alertDialogBuilder
 import com.metallic.chiaki.common.ext.enableFocusableInTouchModeForTv
 import com.metallic.chiaki.common.ext.isTv
+import com.metallic.chiaki.common.ext.showPsnLogoutConfirmation
 import android.content.Intent
 import android.content.res.ColorStateList
 import android.graphics.Bitmap
@@ -16,22 +17,31 @@ import android.view.KeyEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewParent
+import android.widget.PopupMenu
 import androidx.core.view.isGone
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.adapter.FragmentStateAdapter
+import coil.load
 import com.pylux.stream.R
 import com.metallic.chiaki.common.AppIntegrityManager
 import com.metallic.chiaki.common.InAppReviewHelper
 import com.metallic.chiaki.common.Preferences
 import com.metallic.chiaki.common.ext.viewModelFactory
 import com.metallic.chiaki.common.getDatabase
+import com.metallic.chiaki.friends.FriendsService
+import com.metallic.chiaki.trophy.PsnTrophyTokenManager
+import com.metallic.chiaki.trophy.TrophyService
 import com.pylux.stream.databinding.ActivityMainBinding
 import com.metallic.chiaki.settings.SettingsActivity
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class MainActivity : AppCompatActivity() {
     companion object {
@@ -150,6 +160,88 @@ class MainActivity : AppCompatActivity() {
         super.onResume()
         // If the theme was changed in Settings while this activity was paused, recreate to apply it
         if (preferences.getThemeColour() != appliedThemeColour) recreate()
+        // Catches login/logout that happened in Settings, the login screen, or this activity's
+        // own account menu while paused — the icon needs to reflect current state every time this
+        // screen comes back to the foreground, not just once at cold start.
+        refreshAccountIcon()
+    }
+
+    /** Shows/hides the signed-in account icon and keeps its avatar image + presence dot current.
+     *  The avatar URL is cached in Preferences after the first successful fetch (see
+     *  psnAvatarUrl) so returning to this screen doesn't re-fetch it over the network every time.
+     *  Presence (online/offline) is the opposite — it goes stale the moment it's fetched, so
+     *  [fetchAccountDetails] re-fetches it every call rather than caching it. */
+    private fun refreshAccountIcon() {
+        val loggedIn = preferences.hasNpssoToken()
+        binding.accountIconButton.visibility = if (loggedIn) View.VISIBLE else View.GONE
+        if (!loggedIn) return
+
+        val cachedAvatarUrl = preferences.psnAvatarUrl
+        if (cachedAvatarUrl.isNotEmpty()) {
+            binding.accountIcon.load(cachedAvatarUrl) { crossfade(true) }
+        }
+        fetchAccountDetails(needsAvatar = cachedAvatarUrl.isEmpty())
+    }
+
+    private fun fetchAccountDetails(needsAvatar: Boolean) {
+        lifecycleScope.launch {
+            val (avatarUrl, presence) = withContext(Dispatchers.IO) {
+                val token = PsnTrophyTokenManager(preferences).getValidToken()
+                    ?: return@withContext null to null
+                val avatarUrl = if (needsAvatar) TrophyService.fetchAvatarUrl(token) else null
+
+                // Not preferences.psnAccountId — that's only populated by the separate Remote
+                // Play token exchange (PsnTokenManager), which can fail or simply never run even
+                // when this trophy/friends token works fine, silently leaving it empty and the
+                // dot permanently hidden. fetchMyAccountId resolves it the same reliable way
+                // FriendsRepository already does for its own "is this message mine" check.
+                val accountId = FriendsService.fetchMyAccountId(token)
+                val presence = if (!accountId.isNullOrEmpty())
+                    FriendsService.fetchPresences(token, listOf(accountId))[accountId]
+                else null
+
+                avatarUrl to presence
+            }
+
+            if (!avatarUrl.isNullOrEmpty()) {
+                preferences.psnAvatarUrl = avatarUrl
+                binding.accountIcon.load(avatarUrl) { crossfade(true) }
+            }
+
+            // Left hidden (rather than defaulting to the offline drawable) on a failed fetch —
+            // an explicit "unknown" over a guessed-wrong "offline" that might just be a dropped
+            // request. "Appear Offline" (a PSN privacy setting) needs no separate handling here —
+            // Sony's own API already reports it identically to actually being offline, matching
+            // what every other app/user sees, so it falls straight into the offline branch below.
+            if (presence != null) {
+                binding.accountStatusDot.visibility = View.VISIBLE
+                binding.accountStatusDot.setBackgroundResource(
+                    when
+                    {
+                        presence.isBusy -> R.drawable.bg_friend_busy_dot
+                        presence.isOnline -> R.drawable.bg_friend_online_dot
+                        else -> R.drawable.bg_friend_offline_dot
+                    }
+                )
+            } else {
+                binding.accountStatusDot.visibility = View.GONE
+            }
+        }
+    }
+
+    private fun showAccountMenu() {
+        val popup = PopupMenu(this, binding.accountIconButton)
+        popup.menu.add(0, 0, 0, R.string.account_menu_log_out)
+        popup.setOnMenuItemClickListener {
+            // recreate() rather than just refreshAccountIcon() — logging out here needs to put
+            // the whole screen back in its logged-out state (Library/Catalog's own "Log In"
+            // button included, via CloudPlayFragment's normal login-required check on create),
+            // not just this icon; refreshAccountIcon() alone left the rest of the page showing
+            // stale logged-in content underneath a hidden account icon.
+            showPsnLogoutConfirmation(preferences) { recreate() }
+            true
+        }
+        popup.show()
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -222,6 +314,11 @@ class MainActivity : AppCompatActivity() {
             }
         })
 
+        // Account (only visible once signed in — see refreshAccountIcon)
+        binding.accountIconButton.setOnClickListener {
+            showAccountMenu()
+        }
+
         // Friends
         binding.friendsIcon.setOnClickListener {
             com.metallic.chiaki.friends.FriendsActivity.start(this)
@@ -250,6 +347,7 @@ class MainActivity : AppCompatActivity() {
             }
             binding.remotePlayButton.onFocusChangeListener = primaryFocusHighlight
             binding.cloudPlayButton.onFocusChangeListener = primaryFocusHighlight
+            binding.accountIconButton.onFocusChangeListener = primaryFocusHighlight
             binding.friendsIcon.onFocusChangeListener = primaryFocusHighlight
             binding.settingsIcon.onFocusChangeListener = primaryFocusHighlight
         }
@@ -333,7 +431,7 @@ class MainActivity : AppCompatActivity() {
         )
         val primaryIds = setOf(
             R.id.remotePlayButton, R.id.cloudPlayButton,
-            R.id.settingsIcon, R.id.friendsIcon
+            R.id.accountIconButton, R.id.settingsIcon, R.id.friendsIcon
         )
 
         val focusedInCloud = cloudRv?.findContainingItemView(focused)
@@ -536,7 +634,7 @@ class MainActivity : AppCompatActivity() {
         )
         val primaryIds = setOf(
             R.id.remotePlayButton, R.id.cloudPlayButton,
-            R.id.settingsIcon, R.id.friendsIcon
+            R.id.accountIconButton, R.id.settingsIcon, R.id.friendsIcon
         )
 
         val focusedInCloud = focused?.let { cloudRv?.findContainingItemView(it) }

--- a/android/app/src/main/java/com/metallic/chiaki/session/ControllerRemapCapture.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/session/ControllerRemapCapture.kt
@@ -62,6 +62,11 @@ class ControllerRemapCapture(
 		captureModifier = null
 
 		val dialog = InputCaptureDialog()
+		// Subclassing AlertDialog directly (needed to override dispatchKeyEvent/
+		// dispatchGenericMotionEvent for capture) bypasses AppAlertDialogBuilder's themed
+		// background — applying the same drawable it uses so this still matches every other
+		// dialog in the app instead of falling back to the platform default.
+		dialog.window?.setBackgroundDrawableResource(R.drawable.bg_disclaimer_box)
 		dialog.setTitle(action.displayName)
 		dialog.setMessage(context.getString(R.string.controller_remap_press_button))
 		dialog.setButton(AlertDialog.BUTTON_NEGATIVE, context.getString(R.string.action_cancel)) { _, _ ->

--- a/android/app/src/main/java/com/metallic/chiaki/settings/SettingsActivity.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/settings/SettingsActivity.kt
@@ -33,13 +33,30 @@ class SettingsActivity: AppCompatActivity(), PreferenceFragmentCompat.OnPreferen
 		setSupportActionBar(binding.toolbar)
 		binding.backButton.setOnClickListener { onBackPressedDispatcher.onBackPressed() }
 
-		val rootFragment = SettingsFragment()
-		replaceFragment(rootFragment, false)
 		supportFragmentManager.addOnBackStackChangedListener {
 			val titleFragment = supportFragmentManager.findFragmentById(R.id.settingsFragment) as? TitleFragment ?: return@addOnBackStackChangedListener
 			binding.titleTextView.text = titleFragment.getTitle(resources)
 		}
-		binding.titleTextView.text = rootFragment.getTitle(resources)
+
+		if (savedInstanceState == null)
+		{
+			// Only on a genuinely fresh launch — on a config-change recreate (e.g. rotating while
+			// a ListPreference's dialog is open), the FragmentManager has already restored the
+			// previous SettingsFragment instance (and reconnected the open PreferenceDialogFragment
+			// to it as its target fragment) as part of super.onCreate() above. Replacing it again
+			// here swapped in a second, different SettingsFragment instance that dialog was never
+			// attached to, leaving it pointing at a now-discarded fragment — which crashed with
+			// "Target fragment must implement TargetFragment interface" as soon as the dialog tried
+			// to restore itself against it.
+			val rootFragment = SettingsFragment()
+			replaceFragment(rootFragment, false)
+			binding.titleTextView.text = rootFragment.getTitle(resources)
+		}
+		else
+		{
+			val restoredFragment = supportFragmentManager.findFragmentById(R.id.settingsFragment) as? TitleFragment
+			binding.titleTextView.text = restoredFragment?.getTitle(resources) ?: ""
+		}
 	}
 
 	/** Circle/B as a controller shortcut for the back button — same equivalence QuickSettingsPanel

--- a/android/app/src/main/java/com/metallic/chiaki/settings/SettingsFragment.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/settings/SettingsFragment.kt
@@ -16,7 +16,7 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.preference.*
 import com.metallic.chiaki.cloudplay.PsnLoginActivity
-import com.metallic.chiaki.common.ext.alertDialogBuilder
+import com.metallic.chiaki.common.ext.showPsnLogoutConfirmation
 import com.pylux.stream.BuildConfig
 import com.pylux.stream.R
 import com.metallic.chiaki.common.LicenseAgreementActivity
@@ -390,7 +390,13 @@ class SettingsFragment: PreferenceFragmentCompat(), TitleFragment
 			preference.title = getString(R.string.preferences_psn_logout_title)
 			preference.summary = getString(R.string.preferences_psn_login_summary_logged_in)
 			preference.setIcon(R.drawable.ic_close_white)
-			preference.setOnPreferenceClickListener { showLogoutConfirmation(preferences); true }
+			preference.setOnPreferenceClickListener {
+				requireContext().showPsnLogoutConfirmation(preferences) {
+					updatePsnAccountPreference()
+					updateLocalePreference()
+				}
+				true
+			}
 		}
 		else
 		{
@@ -428,30 +434,6 @@ class SettingsFragment: PreferenceFragmentCompat(), TitleFragment
 			localePreference.isEnabled = false
 			localePreference.summary = getString(R.string.preferences_locale_summary_not_set)
 		}
-	}
-
-	private fun showLogoutConfirmation(preferences: Preferences)
-	{
-		requireContext().alertDialogBuilder()
-			.setTitle(R.string.preferences_psn_logout_title)
-			.setMessage(R.string.preferences_psn_logout_message)
-			.setPositiveButton(R.string.preferences_psn_logout_confirm) { _, _ ->
-				performLogout(preferences)
-			}
-			.setNegativeButton(R.string.action_cancel, null)
-			.show()
-	}
-
-	private fun performLogout(preferences: Preferences)
-	{
-		preferences.clearNpssoToken()
-		preferences.psnAuthToken = ""
-		preferences.psnRefreshToken = ""
-		preferences.psnAuthTokenExpiry = 0L
-		preferences.psnAccountId = ""
-		updatePsnAccountPreference()
-		updateLocalePreference()
-		Toast.makeText(requireContext(), R.string.preferences_psn_logout_success, Toast.LENGTH_SHORT).show()
 	}
 
 	override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?)

--- a/android/app/src/main/java/com/metallic/chiaki/stream/QuickSettingsPanel.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/stream/QuickSettingsPanel.kt
@@ -572,7 +572,7 @@ class QuickSettingsPanel(
 		fun bindSpinner(spinner: Spinner, entries: List<String>, values: List<String>, current: String, selected: (String) -> Unit)
 		{
 			spinner.adapter = ArrayAdapter(activity, R.layout.item_quick_settings_spinner_item, entries).apply {
-				setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+				setDropDownViewResource(R.layout.dropdown_menu_popup_item)
 			}
 			spinner.setSelection(values.indexOf(current).coerceAtLeast(0), false)
 			spinner.onItemSelectedListener = object: AdapterView.OnItemSelectedListener {
@@ -1414,14 +1414,15 @@ class QuickSettingsPanel(
 	{
 		val row = ItemQuickSettingsDropdownBinding.inflate(activity.layoutInflater, container, true)
 		row.quickSettingsDropdownLabel.text = activity.getString(labelRes)
-		// The closed spinner's text needs its own white-text layout — StreamTheme is a Light
-		// MaterialComponents theme, so the system default item layout renders near-black text
-		// that's unreadable against this dark panel. The dropdown list popup keeps the system
-		// default layout, since that popup already renders on a light background where dark
-		// text is legible.
+		// Both the closed spinner and its open dropdown list need their own white-text layouts —
+		// StreamTheme is a Light MaterialComponents theme, so the system default item layouts
+		// render near-black text on a plain white popup, unreadable/inconsistent against this
+		// dark panel. dropdown_menu_popup_item pairs with the Spinner's own popupBackground (see
+		// item_quick_settings_dropdown.xml) for the dark, theme-accent-bordered look used
+		// everywhere else in the app.
 		row.quickSettingsDropdownSpinner.adapter =
 			ArrayAdapter(activity, R.layout.item_quick_settings_spinner_item, entries).apply {
-				setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+				setDropDownViewResource(R.layout.dropdown_menu_popup_item)
 			}
 		row.quickSettingsDropdownSpinner.setSelection(values.indexOf(currentValue).coerceAtLeast(0), false)
 		row.quickSettingsDropdownSpinner.onItemSelectedListener = object: AdapterView.OnItemSelectedListener

--- a/android/app/src/main/res/drawable/bg_friend_busy_dot.xml
+++ b/android/app/src/main/res/drawable/bg_friend_busy_dot.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="#FFC107" />
+    <stroke android:width="2dp" android:color="#F0121212" />
+</shape>

--- a/android/app/src/main/res/drawable/bg_popup_menu.xml
+++ b/android/app/src/main/res/drawable/bg_popup_menu.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Same grey-box-with-accent-border language as bg_disclaimer_box.xml, reused here so every
+     PopupMenu in the app (sort/filter menus, the account menu, etc.) reads as the same family of
+     surface as the app's dialogs, rather than the platform's unstyled default popup background. -->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="?attr/pyluxAccent" />
+            <corners android:radius="12dp" />
+        </shape>
+    </item>
+    <item
+        android:bottom="2dp"
+        android:left="2dp"
+        android:right="2dp"
+        android:top="2dp">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/disclaimer_box_background" />
+            <corners android:radius="10dp" />
+        </shape>
+    </item>
+</layer-list>

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -88,13 +88,21 @@
 
                 </LinearLayout>
 
-                <!-- Center: Pylux logo - absolutely centered -->
+                <!-- Center: Pylux logo — sized to the space left between the two islands rather
+                     than a fixed 258dp centered in the parent. In landscape there's always more
+                     than 258dp free either side, so fitCenter's height-bound scaling (29dp,
+                     unchanged) renders it identically to before; in portrait the islands (now
+                     three icons wide on the right, since the account icon was added) can leave
+                     less than 258dp between them, and without this the fixed-width logo overlapped
+                     the icons instead of shrinking to fit. -->
                 <ImageView
                     android:id="@+id/appTitle"
-                    android:layout_width="258dp"
+                    android:layout_width="0dp"
                     android:layout_height="29dp"
-                    android:layout_centerInParent="true"
-                    android:adjustViewBounds="true"
+                    android:layout_toEndOf="@id/modeIsland"
+                    android:layout_toStartOf="@id/actionIsland"
+                    android:layout_centerVertical="true"
+                    android:scaleType="fitCenter"
                     android:contentDescription="@string/app_name"
                     android:src="@drawable/cloudpad_logo" />
 
@@ -110,6 +118,58 @@
                     android:background="@drawable/icon_island_background"
                     android:paddingStart="3dp"
                     android:paddingEnd="3dp">
+
+                    <!-- Signed-in account icon — only visible once logged in (see
+                         MainActivity.refreshAccountIcon), tap opens a "Log Out" dropdown. -->
+                    <FrameLayout
+                        android:id="@+id/accountIconButton"
+                        android:layout_width="44dp"
+                        android:layout_height="40dp"
+                        android:background="?attr/selectableItemBackgroundBorderless"
+                        android:focusable="true"
+                        android:clickable="true"
+                        android:visibility="gone">
+
+                        <!-- Sized to exactly the avatar circle (not the wider touch target above)
+                             so the status dot below can hug its bottom-right edge, same as the
+                             Friends list's own avatar+dot FrameLayout. -->
+                        <FrameLayout
+                            android:layout_width="28dp"
+                            android:layout_height="28dp"
+                            android:layout_gravity="center">
+
+                            <com.google.android.material.card.MaterialCardView
+                                android:layout_width="match_parent"
+                                android:layout_height="match_parent"
+                                app:cardCornerRadius="14dp"
+                                app:cardElevation="0dp"
+                                app:strokeWidth="1.5dp"
+                                app:strokeColor="?attr/pyluxAccent">
+
+                                <ImageView
+                                    android:id="@+id/accountIcon"
+                                    android:layout_width="match_parent"
+                                    android:layout_height="match_parent"
+                                    android:scaleType="centerCrop"
+                                    android:contentDescription="@string/action_account" />
+
+                            </com.google.android.material.card.MaterialCardView>
+
+                            <!-- Own online/offline presence — same bg_friend_online_dot/
+                                 offline_dot drawables and logic as the Friends list (see
+                                 MainActivity.refreshAccountIcon). Hidden until the first
+                                 successful presence fetch so it never shows a guessed state. -->
+                            <View
+                                android:id="@+id/accountStatusDot"
+                                android:layout_width="10dp"
+                                android:layout_height="10dp"
+                                android:layout_gravity="bottom|end"
+                                android:background="@drawable/bg_friend_offline_dot"
+                                android:visibility="gone" />
+
+                        </FrameLayout>
+
+                    </FrameLayout>
 
                     <!-- Friends Icon -->
                     <ImageView

--- a/android/app/src/main/res/layout/dialog_allocation_progress.xml
+++ b/android/app/src/main/res/layout/dialog_allocation_progress.xml
@@ -36,7 +36,8 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintVertical_bias="0.7">
 
-            <!-- Progress message -->
+            <!-- Progress message — solid grey + theme-accent border (bg_disclaimer_box), matching
+                 every other box in the app, rather than a translucent black plate. -->
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/progressTextView"
                 android:layout_width="wrap_content"
@@ -47,17 +48,22 @@
                 android:textAlignment="center"
                 android:gravity="center"
                 android:padding="16dp"
-                android:background="#40000000"
+                android:background="@drawable/bg_disclaimer_box"
                 android:layout_marginBottom="24dp" />
 
-            <!-- Cancel button -->
+            <!-- Cancel button — same solid grey + theme-accent border, via MaterialButton's own
+                 stroke/cornerRadius attrs (a raw android:background would fight its internal
+                 shape drawable) rather than a translucent tint. -->
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/cancelButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="Cancel"
                 android:textColor="#FFFFFF"
-                app:backgroundTint="#40000000"
+                app:backgroundTint="@color/disclaimer_box_background"
+                app:strokeColor="?attr/pyluxAccent"
+                app:strokeWidth="2dp"
+                app:cornerRadius="10dp"
                 android:paddingStart="32dp"
                 android:paddingEnd="32dp"
                 android:paddingTop="12dp"

--- a/android/app/src/main/res/layout/dialog_touch_controls_customise.xml
+++ b/android/app/src/main/res/layout/dialog_touch_controls_customise.xml
@@ -26,7 +26,7 @@
 		android:id="@+id/touchControlSpinner"
 		android:layout_width="match_parent"
 		android:layout_height="48dp"
-		android:popupBackground="#FF4A4A4A" />
+		android:popupBackground="@drawable/bg_popup_menu" />
 
 	<TextView
 		android:id="@+id/touchControlSizeLabel"

--- a/android/app/src/main/res/layout/dropdown_menu_popup_item.xml
+++ b/android/app/src/main/res/layout/dropdown_menu_popup_item.xml
@@ -5,4 +5,5 @@
     android:padding="16dp"
     android:ellipsize="end"
     android:maxLines="1"
-    android:textAppearance="?attr/textAppearanceSubtitle1"/>
+    android:textAppearance="?attr/textAppearanceSubtitle1"
+    android:textColor="@android:color/white"/>

--- a/android/app/src/main/res/layout/item_quick_settings_dropdown.xml
+++ b/android/app/src/main/res/layout/item_quick_settings_dropdown.xml
@@ -19,12 +19,15 @@
     <!-- backgroundTint covers the dropdown arrow too, not just a fill — the Spinner's default
          background drawable (arrow included) is meant for StreamTheme's Light base and renders
          near-black, unreadable against this dark panel, same underlying issue as the closed
-         spinner's item text (see item_quick_settings_spinner_item.xml). -->
+         spinner's item text (see item_quick_settings_spinner_item.xml). popupBackground is the
+         open dropdown list itself — same reasoning, StreamTheme's Light base otherwise renders
+         it as a plain white box; bg_popup_menu matches every other popup/dropdown in the app. -->
     <Spinner
         android:id="@+id/quickSettingsDropdownSpinner"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="4dp"
-        android:backgroundTint="@android:color/white" />
+        android:backgroundTint="@android:color/white"
+        android:popupBackground="@drawable/bg_popup_menu" />
 
 </LinearLayout>

--- a/android/app/src/main/res/layout/stream_quick_settings_panel.xml
+++ b/android/app/src/main/res/layout/stream_quick_settings_panel.xml
@@ -74,6 +74,8 @@
             android:scaleType="centerCrop"
             android:contentDescription="@null" />
 
+        <!-- Wraps to 2 lines instead of ellipsizing — the full title should stay readable rather
+             than truncating with "…" for the (fairly common) long PS titles. -->
         <TextView
             android:id="@+id/quickSettingsGameNameText"
             android:layout_width="0dp"
@@ -82,8 +84,7 @@
             android:layout_marginStart="8dp"
             android:textColor="@android:color/white"
             android:textSize="12sp"
-            android:maxLines="1"
-            android:ellipsize="end" />
+            android:maxLines="2" />
 
     </LinearLayout>
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -262,6 +262,8 @@
     <string name="trophy_filter_platinum">Platinum</string>
     <string name="trophy_filter_no_matches">No trophies match this filter.</string>
     <string name="action_friends">Friends</string>
+    <string name="action_account">Account</string>
+    <string name="account_menu_log_out">Log Out</string>
     <string name="friends_empty_state">No friends found on this PSN account.</string>
     <string name="friend_chat_empty_state">No messages yet — say hi!</string>
     <string name="friend_chat_input_hint">Message</string>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -11,6 +11,16 @@
         <item name="materialAlertDialogTheme">@style/AppTheme.AlertDialog</item>
         <item name="alertDialogTheme">@style/AppTheme.AlertDialog.NonMaterial</item>
         <item name="android:windowActivityTransitions">true</item>
+        <!-- Every PopupMenu in the app (sort/filter menus, the account menu, etc.) is built with
+             a plain `PopupMenu(context, anchor)` call, which resolves its appearance from this
+             one theme attribute — styling it here covers every call site at once rather than
+             needing each one touched individually. See AppPopupMenuStyle below. -->
+        <item name="android:popupMenuStyle">@style/AppPopupMenuStyle</item>
+        <!-- A Toolbar's own "⋮" overflow menu (e.g. Controller Remap's "Restore to defaults")
+             resolves through this attribute instead of popupMenuStyle above — confirmed by it
+             still showing the platform default even with popupMenuStyle already set. Same shared
+             style either way. -->
+        <item name="actionOverflowMenuStyle">@style/AppPopupMenuStyle</item>
         <!-- Pylux brand colour attrs — Neon Pink default -->
         <item name="pyluxAccent">@color/accent</item>
         <item name="pyluxAccentLight">@color/accent_light</item>
@@ -161,12 +171,22 @@
         <item name="colorPrimary">@color/accent</item>
         <item name="colorControlActivated">?attr/pyluxAccent</item>
         <item name="materialButtonStyle">@style/AppTheme.AlertDialog.Button</item>
+        <item name="android:windowBackground">@drawable/bg_disclaimer_box</item>
     </style>
 
+    <!-- androidx.preference's ListPreferenceDialogFragmentCompat/EditTextPreferenceDialogFragmentCompat
+         (Locale, Image Processing, Resolution, FPS, Bitrate, Codec, Datacenter, Theme Colour —
+         every "pop up box" preference in Settings) build via plain AlertDialog.Builder(context),
+         which resolves through this attr rather than materialAlertDialogTheme above — confirmed
+         against the androidx.preference 1.2.0 sources. Without windowBackground here they fell
+         back to Theme.AppCompat.Dialog.Alert's own default (a plain light dialog), the one gap
+         AppAlertDialogBuilder's programmatic override never reached since these dialogs are never
+         built through it. -->
     <style name="AppTheme.AlertDialog.NonMaterial" parent="Theme.AppCompat.Dialog.Alert">
         <item name="android:textColorPrimary">@android:color/primary_text_dark</item>
         <item name="materialButtonStyle">@style/AppTheme.AlertDialog.Button</item>
         <item name="colorControlActivated">?attr/pyluxAccent</item>
+        <item name="android:windowBackground">@drawable/bg_disclaimer_box</item>
     </style>
 
     <style name="AppTheme.AlertDialog.Button" parent="Widget.MaterialComponents.Button.TextButton.Dialog">
@@ -195,6 +215,19 @@
         <item name="android:textColorPrimary">@android:color/primary_text_dark</item>
         <item name="colorPrimary">@color/accent_orange</item>
         <item name="colorControlActivated">?attr/pyluxAccent</item>
+    </style>
+
+    <!-- Shared look for every PopupMenu in the app — see android:popupMenuStyle on AppTheme. -->
+    <style name="AppPopupMenuStyle" parent="Widget.AppCompat.PopupMenu">
+        <item name="android:popupBackground">@drawable/bg_popup_menu</item>
+        <!-- Scopes the white item-text override to just this popup's own inflated views,
+             rather than touching android:textColorPrimary on AppTheme itself, which is read by
+             far too many other unrelated widgets app-wide to safely override globally. -->
+        <item name="android:theme">@style/ThemeOverlay.App.PopupMenu</item>
+    </style>
+
+    <style name="ThemeOverlay.App.PopupMenu" parent="ThemeOverlay.AppCompat">
+        <item name="android:textColorPrimary">@android:color/white</item>
     </style>
 
     <style name="MageTheme" parent="Theme.MaterialComponents.NoActionBar">

--- a/android/app/src/test/java/com/metallic/chiaki/friends/FriendsServiceParsingTest.kt
+++ b/android/app/src/test/java/com/metallic/chiaki/friends/FriendsServiceParsingTest.kt
@@ -17,6 +17,7 @@ class FriendsServiceParsingTest {
             onlineId = "Minionbanana27",
             avatarUrl = "https://static-resource.np.community.playstation.net/avatar_m/SCEI/I0005_m.png",
             isOnline = true,
+            isBusy = true,
             currentGame = "Marvel Rivals",
             lastOnlineDateMs = null
         ),
@@ -25,6 +26,7 @@ class FriendsServiceParsingTest {
             onlineId = "CKGray",
             avatarUrl = "",
             isOnline = false,
+            isBusy = false,
             currentGame = "",
             lastOnlineDateMs = 1731000000000L
         )


### PR DESCRIPTION
Main screen top bar:
- Adds a signed-in profile icon next to Friends/Settings, with a tap menu to log out (reusing the shared logout confirmation).
- Shows a live online/busy/offline status dot on it, matching Sony's separate `availability` field (busy stays "online" in onlineStatus, so isOnline alone can't tell them apart) — same dot now also shows correctly in the Friends list.
- Logo now sizes to the space between the two icon islands instead of a fixed width, fixing it overlapping the icons in portrait.

Pop-up/dropdown styling, unified to the app's grey+accent-border look:
- Settings' ListPreference/EditTextPreference dialogs (Locale, Image Processing, Resolution, FPS, Bitrate, Codec, Datacenter, Theme Colour) build via a different theme path than the app's other dialogs and never got the themed background — fixed centrally.
- Quick Menu's dropdowns (Image Processing etc.) and the touch controls customSystem spinner now use the same themed popup + white text instead of the platform default.
- The controller remap page's "⋮" overflow menu (Restore to Defaults) uses a third, separate theme attribute from the above two — wired to the same shared style.
- The controller remap capture dialog ("press a button") bypassed the shared dialog builder entirely; now explicitly themed to match.
- The game-launch splash screen's status text and Cancel button were translucent instead of themed; now solid grey with an accent border.

Bug fixes:
- SettingsActivity crashed on rotation while a preference dialog was open ("Target fragment must implement TargetFragment interface") — it was unconditionally rebuilding its fragment on every onCreate, including config-change recreates, discarding the fragment the system had already correctly restored out from under the open dialog. Also missing the same configChanges the rest of the app's activities use to avoid recreating (and losing plain dialogs, like the logout confirmation) on rotation at all.
- Quick Menu's current-game title now wraps instead of truncating.