### PR TITLE
Add customizable Performance Overlay, remove profile status dot, cach…

### DIFF
--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RELEASE_NOTES: >-
-        Added a profile icon with a live online/busy/offline status dot next to Friends on the main screen; fixed every unstyled pop-up/dropdown in the app (Settings preferences, Quick Menu dropdowns, the controller remap overflow menu, the game-launch splash screen) to match the app's themed grey-and-accent-border look; fixed a Settings crash and a lost logout dialog when rotating the device; and fixed the header logo overlapping the top-bar icons in portrait.
+        Added a customizable Performance Overlay: Full and Minimal view modes (Minimal shown by default), a Configure Overlay dialog with an opacity slider and drag-to-reposition, including a fix for the overlay disappearing while being moved and stretching after saving a new position; removed the online/busy/offline status dot from the main menu profile icon; fixed the main menu search icon not matching the other header icons' grey colour; and a small rendering performance improvement for the FSR upscaling shader.
 
     steps:
       - name: Checkout repo

--- a/android/app/src/main/java/com/metallic/chiaki/cloudplay/ping/DatacenterPing.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/cloudplay/ping/DatacenterPing.kt
@@ -39,7 +39,7 @@ object DatacenterPing
 {
 	private const val TAG = "DatacenterPing"
 	private const val PING_TIMEOUT_MS = 15000L  // 15 seconds (Qt line 242)
-	
+
 	/**
 	 * Ping multiple datacenters using senkusha echo/ping functionality
 	 *

--- a/android/app/src/main/java/com/metallic/chiaki/common/Preferences.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/common/Preferences.kt
@@ -64,6 +64,8 @@ class Preferences(context: Context)
 		const val FSR_SHARPENING_MAX = 100
 		const val FSR_SHARPENING_DEFAULT = 50
 
+		const val PERFORMANCE_OVERLAY_OPACITY_DEFAULT = 50
+
 		private const val CLOUD_STORE_LOCALE_KEY = "cloud_store_locale"
 		private const val CLOUD_ACCOUNT_LOCALE_KEY = "cloud_account_locale"
 		private const val CLOUD_STORE_LOCALE_USER_SELECTED_KEY = "cloud_store_locale_user_selected"
@@ -175,6 +177,41 @@ class Preferences(context: Context)
 	var showPerformanceOverlay
 		get() = sharedPreferences.getBoolean(showPerformanceOverlayKey, false)
 		set(value) { sharedPreferences.edit().putBoolean(showPerformanceOverlayKey, value).apply() }
+
+	val performanceOverlayModeKey get() = resources.getString(R.string.preferences_performance_overlay_mode_key)
+	/** "full" (every metric) or "minimal" (FPS/Bitrate/Resolution/Video Loss/Drops/Ping only) —
+	 *  see PerformanceOverlayView.OverlayMode. Defaults to "minimal" — the lighter view is what a
+	 *  user turning the overlay on for the first time should land on; "full" only sticks once
+	 *  they've explicitly picked it from the dropdown. */
+	var performanceOverlayMode: String
+		get() = sharedPreferences.getString(performanceOverlayModeKey, "minimal") ?: "minimal"
+		set(value) { sharedPreferences.edit().putString(performanceOverlayModeKey, value).apply() }
+
+	val performanceOverlayOpacityKey get() = resources.getString(R.string.preferences_performance_overlay_opacity_key)
+	/** 0 (fully transparent) – 100 (fully opaque), applied to both the overlay's background fill
+	 *  and its theme-accent border — not to the metric text, which stays fully legible. */
+	var performanceOverlayOpacityPercent: Int
+		get() = sharedPreferences.getInt(performanceOverlayOpacityKey, PERFORMANCE_OVERLAY_OPACITY_DEFAULT).coerceIn(0, 100)
+		set(value) { sharedPreferences.edit().putInt(performanceOverlayOpacityKey, value.coerceIn(0, 100)).apply() }
+
+	val performanceOverlayOffsetXKey get() = resources.getString(R.string.preferences_performance_overlay_offset_x_key)
+	val performanceOverlayOffsetYKey get() = resources.getString(R.string.preferences_performance_overlay_offset_y_key)
+	/** Per-mille of the stream view's width/height, same convention as TouchControlCustomization's
+	 *  offsetXPermille/offsetYPermille — survives orientation/resolution changes since it's
+	 *  relative, not absolute pixels. (0, 0) is the overlay's default top-start position. */
+	var performanceOverlayOffsetXPermille: Int
+		get() = sharedPreferences.getInt(performanceOverlayOffsetXKey, 0)
+		set(value) { sharedPreferences.edit().putInt(performanceOverlayOffsetXKey, value).apply() }
+	var performanceOverlayOffsetYPermille: Int
+		get() = sharedPreferences.getInt(performanceOverlayOffsetYKey, 0)
+		set(value) { sharedPreferences.edit().putInt(performanceOverlayOffsetYKey, value).apply() }
+
+	fun resetPerformanceOverlayCustomization()
+	{
+		performanceOverlayOpacityPercent = PERFORMANCE_OVERLAY_OPACITY_DEFAULT
+		performanceOverlayOffsetXPermille = 0
+		performanceOverlayOffsetYPermille = 0
+	}
 
 	val pipEnabledKey get() = resources.getString(R.string.preferences_pip_enabled_key)
 	var pipEnabled

--- a/android/app/src/main/java/com/metallic/chiaki/main/MainActivity.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/main/MainActivity.kt
@@ -166,11 +166,9 @@ class MainActivity : AppCompatActivity() {
         refreshAccountIcon()
     }
 
-    /** Shows/hides the signed-in account icon and keeps its avatar image + presence dot current.
-     *  The avatar URL is cached in Preferences after the first successful fetch (see
-     *  psnAvatarUrl) so returning to this screen doesn't re-fetch it over the network every time.
-     *  Presence (online/offline) is the opposite — it goes stale the moment it's fetched, so
-     *  [fetchAccountDetails] re-fetches it every call rather than caching it. */
+    /** Shows/hides the signed-in account icon and keeps its avatar image current. The avatar URL
+     *  is cached in Preferences after the first successful fetch (see psnAvatarUrl) so returning
+     *  to this screen doesn't re-fetch it over the network every time. */
     private fun refreshAccountIcon() {
         val loggedIn = preferences.hasNpssoToken()
         binding.accountIconButton.visibility = if (loggedIn) View.VISIBLE else View.GONE
@@ -179,52 +177,22 @@ class MainActivity : AppCompatActivity() {
         val cachedAvatarUrl = preferences.psnAvatarUrl
         if (cachedAvatarUrl.isNotEmpty()) {
             binding.accountIcon.load(cachedAvatarUrl) { crossfade(true) }
+        } else {
+            fetchAvatar()
         }
-        fetchAccountDetails(needsAvatar = cachedAvatarUrl.isEmpty())
     }
 
-    private fun fetchAccountDetails(needsAvatar: Boolean) {
+    private fun fetchAvatar() {
         lifecycleScope.launch {
-            val (avatarUrl, presence) = withContext(Dispatchers.IO) {
+            val avatarUrl = withContext(Dispatchers.IO) {
                 val token = PsnTrophyTokenManager(preferences).getValidToken()
-                    ?: return@withContext null to null
-                val avatarUrl = if (needsAvatar) TrophyService.fetchAvatarUrl(token) else null
-
-                // Not preferences.psnAccountId — that's only populated by the separate Remote
-                // Play token exchange (PsnTokenManager), which can fail or simply never run even
-                // when this trophy/friends token works fine, silently leaving it empty and the
-                // dot permanently hidden. fetchMyAccountId resolves it the same reliable way
-                // FriendsRepository already does for its own "is this message mine" check.
-                val accountId = FriendsService.fetchMyAccountId(token)
-                val presence = if (!accountId.isNullOrEmpty())
-                    FriendsService.fetchPresences(token, listOf(accountId))[accountId]
-                else null
-
-                avatarUrl to presence
+                    ?: return@withContext null
+                TrophyService.fetchAvatarUrl(token)
             }
 
             if (!avatarUrl.isNullOrEmpty()) {
                 preferences.psnAvatarUrl = avatarUrl
                 binding.accountIcon.load(avatarUrl) { crossfade(true) }
-            }
-
-            // Left hidden (rather than defaulting to the offline drawable) on a failed fetch —
-            // an explicit "unknown" over a guessed-wrong "offline" that might just be a dropped
-            // request. "Appear Offline" (a PSN privacy setting) needs no separate handling here —
-            // Sony's own API already reports it identically to actually being offline, matching
-            // what every other app/user sees, so it falls straight into the offline branch below.
-            if (presence != null) {
-                binding.accountStatusDot.visibility = View.VISIBLE
-                binding.accountStatusDot.setBackgroundResource(
-                    when
-                    {
-                        presence.isBusy -> R.drawable.bg_friend_busy_dot
-                        presence.isOnline -> R.drawable.bg_friend_online_dot
-                        else -> R.drawable.bg_friend_offline_dot
-                    }
-                )
-            } else {
-                binding.accountStatusDot.visibility = View.GONE
             }
         }
     }

--- a/android/app/src/main/java/com/metallic/chiaki/stream/CasVideoSurfaceView.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/stream/CasVideoSurfaceView.kt
@@ -102,7 +102,17 @@ class CasVideoSurfaceView @JvmOverloads constructor(
 		private var uLevelLoc = 0
 		private var uEnabledLoc = 0
 		private var easuProgram = 0
+		private var aEasuPositionLoc = 0
+		private var aEasuTexCoordLoc = 0
+		private var uEasuSTMatrixLoc = 0
+		private var uEasuInputSizeLoc = 0
+		private var uEasuOutputSizeLoc = 0
+		private var uEasuUpscaleLoc = 0
 		private var rcasProgram = 0
+		private var aRcasPositionLoc = 0
+		private var aRcasTexCoordLoc = 0
+		private var uRcasTexelSizeLoc = 0
+		private var uRcasSharpnessLoc = 0
 		private var fsrFramebuffer = 0
 		private var fsrTexture = 0
 		private var surfaceWidth = 1
@@ -161,14 +171,29 @@ class CasVideoSurfaceView @JvmOverloads constructor(
 			surfaceTexture = st
 
 			program = buildProgram(VERTEX_SHADER, CAS_FRAGMENT_SHADER)
-			easuProgram = buildProgram(VERTEX_SHADER, EASU_FRAGMENT_SHADER)
-			rcasProgram = buildProgram(RCAS_VERTEX_SHADER, RCAS_FRAGMENT_SHADER)
 			aPositionLoc = GLES20.glGetAttribLocation(program, "aPosition")
 			aTexCoordLoc = GLES20.glGetAttribLocation(program, "aTexCoord")
 			uSTMatrixLoc = GLES20.glGetUniformLocation(program, "uSTMatrix")
 			uTexelSizeLoc = GLES20.glGetUniformLocation(program, "uTexelSize")
 			uLevelLoc = GLES20.glGetUniformLocation(program, "uLevel")
 			uEnabledLoc = GLES20.glGetUniformLocation(program, "uEnabled")
+
+			// Locations are fixed for a program's lifetime once linked, and (per this override's
+			// own early-return above) these programs are only ever built once — cached here rather
+			// than re-resolved by name every onDrawFrame call.
+			easuProgram = buildProgram(VERTEX_SHADER, EASU_FRAGMENT_SHADER)
+			aEasuPositionLoc = GLES20.glGetAttribLocation(easuProgram, "aPosition")
+			aEasuTexCoordLoc = GLES20.glGetAttribLocation(easuProgram, "aTexCoord")
+			uEasuSTMatrixLoc = GLES20.glGetUniformLocation(easuProgram, "uSTMatrix")
+			uEasuInputSizeLoc = GLES20.glGetUniformLocation(easuProgram, "uInputSize")
+			uEasuOutputSizeLoc = GLES20.glGetUniformLocation(easuProgram, "uOutputSize")
+			uEasuUpscaleLoc = GLES20.glGetUniformLocation(easuProgram, "uUpscale")
+
+			rcasProgram = buildProgram(RCAS_VERTEX_SHADER, RCAS_FRAGMENT_SHADER)
+			aRcasPositionLoc = GLES20.glGetAttribLocation(rcasProgram, "aPosition")
+			aRcasTexCoordLoc = GLES20.glGetAttribLocation(rcasProgram, "aTexCoord")
+			uRcasTexelSizeLoc = GLES20.glGetUniformLocation(rcasProgram, "uTexelSize")
+			uRcasSharpnessLoc = GLES20.glGetUniformLocation(rcasProgram, "uSharpness")
 
 			val surface = Surface(st)
 			mainHandler.post { onSurfaceReady?.invoke(surface) }
@@ -212,28 +237,28 @@ class CasVideoSurfaceView @JvmOverloads constructor(
 			{
 				GLES20.glBindFramebuffer(GLES20.GL_FRAMEBUFFER, fsrFramebuffer)
 				GLES20.glViewport(0, 0, surfaceWidth, surfaceHeight)
-				drawExternal(easuProgram) {
-					GLES20.glUniform2f(GLES20.glGetUniformLocation(easuProgram, "uInputSize"), videoWidth.toFloat(), videoHeight.toFloat())
-					GLES20.glUniform2f(GLES20.glGetUniformLocation(easuProgram, "uOutputSize"), surfaceWidth.toFloat(), surfaceHeight.toFloat())
-					GLES20.glUniform1f(GLES20.glGetUniformLocation(easuProgram, "uUpscale"), if(fsrUpscale) 1f else 0f)
+				drawExternal(easuProgram, aEasuPositionLoc, aEasuTexCoordLoc, uEasuSTMatrixLoc) {
+					GLES20.glUniform2f(uEasuInputSizeLoc, videoWidth.toFloat(), videoHeight.toFloat())
+					GLES20.glUniform2f(uEasuOutputSizeLoc, surfaceWidth.toFloat(), surfaceHeight.toFloat())
+					GLES20.glUniform1f(uEasuUpscaleLoc, if(fsrUpscale) 1f else 0f)
 				}
 				GLES20.glBindFramebuffer(GLES20.GL_FRAMEBUFFER, 0)
 				GLES20.glViewport(0, 0, surfaceWidth, surfaceHeight)
 				drawRcas()
 			}
-			else drawExternal(program) {
+			else drawExternal(program, aPositionLoc, aTexCoordLoc, uSTMatrixLoc) {
 				GLES20.glUniform2f(uTexelSizeLoc, 1f / videoWidth, 1f / videoHeight)
 				GLES20.glUniform1f(uLevelLoc, sharpeningLevel.toFloat())
 				GLES20.glUniform1f(uEnabledLoc, if(sharpeningEnabled) 1f else 0f)
 			}
 		}
 
-		private inline fun drawExternal(shaderProgram: Int, uniforms: () -> Unit)
+		private inline fun drawExternal(shaderProgram: Int, positionLoc: Int, texCoordLoc: Int, stMatrixLoc: Int, uniforms: () -> Unit)
 		{
 			GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT); GLES20.glUseProgram(shaderProgram)
 			GLES20.glActiveTexture(GLES20.GL_TEXTURE0); GLES20.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, textureId)
-			drawQuad(shaderProgram)
-			GLES20.glUniformMatrix4fv(GLES20.glGetUniformLocation(shaderProgram, "uSTMatrix"), 1, false, stMatrix, 0)
+			drawQuad(positionLoc, texCoordLoc)
+			GLES20.glUniformMatrix4fv(stMatrixLoc, 1, false, stMatrix, 0)
 			uniforms(); GLES20.glDrawArrays(GLES20.GL_TRIANGLE_STRIP, 0, 4)
 		}
 
@@ -241,18 +266,16 @@ class CasVideoSurfaceView @JvmOverloads constructor(
 		{
 			GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT); GLES20.glUseProgram(rcasProgram)
 			GLES20.glActiveTexture(GLES20.GL_TEXTURE0); GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, fsrTexture)
-			drawQuad(rcasProgram)
-			GLES20.glUniform2f(GLES20.glGetUniformLocation(rcasProgram, "uTexelSize"), 1f / surfaceWidth, 1f / surfaceHeight)
-			GLES20.glUniform1f(GLES20.glGetUniformLocation(rcasProgram, "uSharpness"), fsrSharpening / 100f)
+			drawQuad(aRcasPositionLoc, aRcasTexCoordLoc)
+			GLES20.glUniform2f(uRcasTexelSizeLoc, 1f / surfaceWidth, 1f / surfaceHeight)
+			GLES20.glUniform1f(uRcasSharpnessLoc, fsrSharpening / 100f)
 			GLES20.glDrawArrays(GLES20.GL_TRIANGLE_STRIP, 0, 4)
 		}
 
-		private fun drawQuad(shaderProgram: Int)
+		private fun drawQuad(positionLoc: Int, texCoordLoc: Int)
 		{
-			val position = GLES20.glGetAttribLocation(shaderProgram, "aPosition")
-			val texCoord = GLES20.glGetAttribLocation(shaderProgram, "aTexCoord")
-			quadVertices.position(0); GLES20.glVertexAttribPointer(position, 2, GLES20.GL_FLOAT, false, VERTEX_STRIDE, quadVertices); GLES20.glEnableVertexAttribArray(position)
-			quadTexCoords.position(0); GLES20.glVertexAttribPointer(texCoord, 2, GLES20.GL_FLOAT, false, VERTEX_STRIDE, quadTexCoords); GLES20.glEnableVertexAttribArray(texCoord)
+			quadVertices.position(0); GLES20.glVertexAttribPointer(positionLoc, 2, GLES20.GL_FLOAT, false, VERTEX_STRIDE, quadVertices); GLES20.glEnableVertexAttribArray(positionLoc)
+			quadTexCoords.position(0); GLES20.glVertexAttribPointer(texCoordLoc, 2, GLES20.GL_FLOAT, false, VERTEX_STRIDE, quadTexCoords); GLES20.glEnableVertexAttribArray(texCoordLoc)
 		}
 	}
 

--- a/android/app/src/main/java/com/metallic/chiaki/stream/PerformanceOverlayView.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/stream/PerformanceOverlayView.kt
@@ -5,12 +5,14 @@ import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.Typeface
+import android.graphics.drawable.GradientDrawable
 import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.TextView
+import com.pylux.stream.R
 import java.util.Locale
 
 class PerformanceOverlayView @JvmOverloads constructor(
@@ -19,8 +21,13 @@ class PerformanceOverlayView @JvmOverloads constructor(
     defStyleAttr: Int = 0
 ) : LinearLayout(context, attrs, defStyleAttr) {
 
+    /** FULL is every metric (the original view); MINIMAL is just the numbers most people
+     *  actually glance at mid-session — FPS, Bitrate, Resolution, Video Loss, Drops and Ping. */
+    enum class OverlayMode { FULL, MINIMAL }
+
     private val headerView: TextView
     private val sparklineView: SparklineView
+    private val latencyCol: LinearLayout
 
     private val labelTotal = metricRow("Total")
     private val labelNet = metricRow("Net")
@@ -37,8 +44,7 @@ class PerformanceOverlayView @JvmOverloads constructor(
 
     init {
         orientation = VERTICAL
-        setBackgroundColor(Color.argb(170, 0, 0, 0))
-        setPadding(5, 3, 5, 3)
+        setPadding(7, 5, 7, 5)
 
         headerView = TextView(context).apply {
             setTextColor(Color.argb(230, 255, 255, 255))
@@ -57,7 +63,7 @@ class PerformanceOverlayView @JvmOverloads constructor(
             orientation = HORIZONTAL
         }
 
-        val latencyCol = buildColumn()
+        latencyCol = buildColumn()
         latencyCol.addView(labelTotal)
         latencyCol.addView(labelNet)
         latencyCol.addView(labelVisual)
@@ -87,19 +93,23 @@ class PerformanceOverlayView @JvmOverloads constructor(
                 ViewGroup.LayoutParams.WRAP_CONTENT
             )
         )
+        // marginStart on both (not just qualityCol) so the gap is consistent whether latencyCol
+        // is showing or not — in Minimal mode latencyCol collapses to width 0, and without their
+        // own margins streamCol/qualityCol would butt directly against each other with no gap at
+        // all, cramping "Res"/"Ping" right up against "FPS"/"VL".
         columns.addView(
             streamCol,
             LayoutParams(
                 ViewGroup.LayoutParams.WRAP_CONTENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT
-            )
+            ).apply { marginStart = dpToPx(6) }
         )
         columns.addView(
             qualityCol,
             LayoutParams(
                 ViewGroup.LayoutParams.WRAP_CONTENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT
-            )
+            ).apply { marginStart = dpToPx(6) }
         )
 
         addView(
@@ -110,7 +120,47 @@ class PerformanceOverlayView @JvmOverloads constructor(
             )
         )
 
+        setOpacityPercent(50)
         visibility = View.GONE
+    }
+
+    private fun resolveAccentColor(): Int
+    {
+        val tv = TypedValue()
+        context.theme.resolveAttribute(R.attr.pyluxAccent, tv, true)
+        return tv.data
+    }
+
+    /** 0 (fully transparent) – 100 (fully opaque), applied to the grey fill and the theme-accent
+     *  border only — the metric text keeps its own fixed alpha regardless, so it stays legible
+     *  even at low overlay opacity. */
+    fun setOpacityPercent(percent: Int)
+    {
+        val alpha = (percent.coerceIn(0, 100) / 100f * 255).toInt()
+        val accent = resolveAccentColor()
+        background = GradientDrawable().apply {
+            shape = GradientDrawable.RECTANGLE
+            cornerRadius = dpToPx(4).toFloat()
+            setColor((alpha shl 24) or 0x2B2B2B)
+            setStroke(dpToPx(1).coerceAtLeast(2), (alpha shl 24) or (accent and 0x00FFFFFF))
+        }
+    }
+
+    fun setMode(mode: OverlayMode)
+    {
+        val minimal = mode == OverlayMode.MINIMAL
+        latencyCol.visibility = if (minimal) View.GONE else View.VISIBLE
+        labelDFPS.visibility = if (minimal) View.GONE else View.VISIBLE
+        sparklineView.visibility = if (minimal) View.GONE else View.VISIBLE
+        labelJit.visibility = if (minimal) View.GONE else View.VISIBLE
+        labelDT.visibility = if (minimal) View.GONE else View.VISIBLE
+        // On-device: after a mode switch (and especially after the freeze/hardware-layer window
+        // move mode puts this view through — see StreamActivity.overlayMoveModeActive), this
+        // view's own rendered width could get stuck narrower than its actual content, clipping
+        // part of it away — a fresh explicit measure/layout/draw pass covers whichever of those
+        // isn't otherwise triggering reliably by itself.
+        requestLayout()
+        invalidate()
     }
 
     private fun buildColumn() = LinearLayout(context).apply {
@@ -165,7 +215,15 @@ class PerformanceOverlayView @JvmOverloads constructor(
             m.fps >= 30f -> Color.rgb(255, 200, 40)
             else -> Color.rgb(255, 80, 80)
         }
-        labelFPS.text = String.format(Locale.US, "FPS %5.1f", m.fps)
+        // Labels within streamCol/qualityCol are padded to a fixed width (%-3s / %-5s below) so
+        // the values that follow start at the same column regardless of label length — "FPS"/
+        // "BT"/"Res" differ from 2-3 chars, "Ping"/"VL"/"Drops" from 2-5, so without padding the
+        // numbers landed at different offsets row to row instead of forming a clean column, most
+        // noticeable in Minimal mode where these six rows are the entire visible content. The
+        // values themselves are left-justified too (%-5.1f, not %5.1f) — right-justifying them
+        // kept the label-to-value gap consistent but left the first digit itself landing at a
+        // different column per row depending on the number's own width (e.g. "60.0" vs " 5.0").
+        labelFPS.text = String.format(Locale.US, "%-3s %-5.1f", "FPS", m.fps)
         labelFPS.setTextColor(fpsColor)
 
         val dfpsColor = when {
@@ -176,7 +234,7 @@ class PerformanceOverlayView @JvmOverloads constructor(
         labelDFPS.text = String.format(Locale.US, "DFPS %5.1f", m.decodedFps)
         labelDFPS.setTextColor(dfpsColor)
 
-        labelBT.text = String.format(Locale.US, "BT %5.1f Mbps", m.bitrate)
+        labelBT.text = String.format(Locale.US, "%-3s %-5.1f Mbps", "BT", m.bitrate)
 
         val resString = when {
             m.height >= 2160 -> "4K"
@@ -186,14 +244,14 @@ class PerformanceOverlayView @JvmOverloads constructor(
             m.height >= 540 -> "540p"
             else -> "${m.width}×${m.height}"
         }
-        labelRes.text = String.format(Locale.US, "Res %6s", resString)
+        labelRes.text = String.format(Locale.US, "%-3s %-6s", "Res", resString)
 
         val rttColor = when {
             data.smoothedPing < 30.0 -> Color.rgb(0, 220, 100)
             data.smoothedPing < 80.0 -> Color.rgb(255, 200, 40)
             else -> Color.rgb(255, 80, 80)
         }
-        labelRTT.text = String.format(Locale.US, "Ping %5.1f ms", data.smoothedPing)
+        labelRTT.text = String.format(Locale.US, "%-5s %-5.1f ms", "Ping", data.smoothedPing)
         labelRTT.setTextColor(rttColor)
 
         val jitColor = when {
@@ -212,10 +270,10 @@ class PerformanceOverlayView @JvmOverloads constructor(
             lossPercent <= 1.0 -> Color.rgb(255, 200, 40)
             else -> Color.rgb(255, 80, 80)
         }
-        labelVL.text = String.format(Locale.US, "VL %5.1f%%", lossPercent)
+        labelVL.text = String.format(Locale.US, "%-5s %-5.1f%%", "VL", lossPercent)
         labelVL.setTextColor(lossColor)
 
-        labelDrops.text = String.format(Locale.US, "Drops %5d", m.drops)
+        labelDrops.text = String.format(Locale.US, "%-5s %-5d", "Drops", m.drops)
 
         sparklineView.setData(data.fpsHistory)
     }

--- a/android/app/src/main/java/com/metallic/chiaki/stream/QuickSettingsPanel.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/stream/QuickSettingsPanel.kt
@@ -79,6 +79,7 @@ import com.pylux.stream.R
 import com.pylux.stream.databinding.ItemQuickSettingsDropdownBinding
 import com.pylux.stream.databinding.ItemQuickSettingsEdittextBinding
 import com.pylux.stream.databinding.ItemQuickSettingsSeekbarBinding
+import com.pylux.stream.databinding.DialogConfigureOverlayBinding
 import com.pylux.stream.databinding.DialogTouchControlsCustomiseBinding
 import com.pylux.stream.databinding.StreamQuickSettingsPanelBinding
 import com.metallic.chiaki.touchcontrols.TouchControl
@@ -140,7 +141,8 @@ class QuickSettingsPanel(
 	private val onFsrChanged: (enabled: Boolean, upscale: Boolean, sharpening: Int) -> Unit,
 	private val onTouchControlsCustomizationChanged: () -> Unit,
 	private val onTouchControlsCustomizationVisibilityChanged: (Boolean) -> Unit,
-	private val onMoveTouchControl: (TouchControl, () -> Unit) -> Unit
+	private val onMoveTouchControl: (TouchControl, () -> Unit) -> Unit,
+	private val onMoveOverlay: (onDone: () -> Unit) -> Unit
 ) {
 	private val panel = StreamQuickSettingsPanelBinding.inflate(activity.layoutInflater).apply {
 		// root.focusable=true (see stream_quick_settings_panel.xml) exists only so a touch tap
@@ -522,7 +524,38 @@ class QuickSettingsPanel(
 		// Touchpad Only additionally stay mutually exclusive with each other.
 		panel.quickSettingsStatsRow.quickSettingsRowSwitch.setOnCheckedChangeListener { _, isChecked ->
 			viewModel.setShowPerformanceOverlay(isChecked)
+			updatePerformanceOverlayRowsVisibility(isChecked)
 		}
+
+		panel.quickSettingsOverlayModeRow.quickSettingsDropdownLabel.text =
+			activity.getString(R.string.quick_settings_overlay_type_title)
+		val overlayModeValues = listOf("full", "minimal")
+		val overlayModeEntries = listOf(R.string.quick_settings_overlay_mode_full, R.string.quick_settings_overlay_mode_minimal).map(activity::getString)
+		panel.quickSettingsOverlayModeRow.quickSettingsDropdownSpinner.adapter =
+			ArrayAdapter(activity, R.layout.item_quick_settings_spinner_item, overlayModeEntries).apply {
+				setDropDownViewResource(R.layout.dropdown_menu_popup_item)
+			}
+		panel.quickSettingsOverlayModeRow.quickSettingsDropdownSpinner.setSelection(
+			overlayModeValues.indexOf(preferences.performanceOverlayMode).coerceAtLeast(0), false
+		)
+		panel.quickSettingsOverlayModeRow.quickSettingsDropdownSpinner.onItemSelectedListener = object: AdapterView.OnItemSelectedListener
+		{
+			override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long)
+			{
+				val mode = overlayModeValues[position]
+				if(mode == preferences.performanceOverlayMode) return
+				preferences.performanceOverlayMode = mode
+				activity.findViewById<PerformanceOverlayView>(R.id.performanceOverlay).setMode(
+					if(mode == "minimal") PerformanceOverlayView.OverlayMode.MINIMAL else PerformanceOverlayView.OverlayMode.FULL
+				)
+			}
+			override fun onNothingSelected(parent: AdapterView<*>?) {}
+		}
+		panel.quickSettingsConfigureOverlayButton.setOnClickListener {
+			dismissImmediately()
+			showConfigureOverlayDialog()
+		}
+
 		panel.quickSettingsOscRow.quickSettingsRowSwitch.setOnCheckedChangeListener { _, checked ->
 			if(checked) panel.quickSettingsTouchpadRow.quickSettingsRowSwitch.isChecked = false
 			viewModel.setOnScreenControlsEnabled(checked)
@@ -734,7 +767,8 @@ class QuickSettingsPanel(
 			panel.quickSettingsDisplayModeStretch
 		).forEach { addFocusHighlight(it, pyluxAccentColor, useForeground = true) }
 		listOf(
-			panel.quickSettingsStatsRow.quickSettingsRowSwitch, panel.quickSettingsOscRow.quickSettingsRowSwitch,
+			panel.quickSettingsStatsRow.quickSettingsRowSwitch, panel.quickSettingsOverlayModeRow.quickSettingsDropdownSpinner,
+			panel.quickSettingsConfigureOverlayButton, panel.quickSettingsOscRow.quickSettingsRowSwitch,
 			panel.quickSettingsTouchpadRow.quickSettingsRowSwitch, panel.quickSettingsMicrophoneRow.quickSettingsRowSwitch,
 			panel.quickSettingsMotionRow.quickSettingsRowSwitch, panel.quickSettingsHapticsRow.quickSettingsRowSwitch,
 			panel.quickSettingsPipRow.quickSettingsRowSwitch,
@@ -1500,6 +1534,7 @@ class QuickSettingsPanel(
 		// state can change elsewhere while it's closed (e.g. PiP forces On-Screen Controls
 		// and Touchpad Only off), so the panel must not show stale state from last time.
 		panel.quickSettingsStatsRow.quickSettingsRowSwitch.isChecked = viewModel.showPerformanceOverlay.value ?: false
+		updatePerformanceOverlayRowsVisibility(panel.quickSettingsStatsRow.quickSettingsRowSwitch.isChecked)
 		panel.quickSettingsOscRow.quickSettingsRowSwitch.isChecked = viewModel.onScreenControlsEnabled.value ?: false
 		panel.quickSettingsOscCustomiseButton.visibility =
 			if(panel.quickSettingsOscRow.quickSettingsRowSwitch.isChecked) View.VISIBLE else View.GONE
@@ -1749,6 +1784,81 @@ class QuickSettingsPanel(
 		isOpen = false
 		panel.root.animate().cancel()
 		if(dialog.isShowing) dialog.dismiss()
+	}
+
+	private fun updatePerformanceOverlayRowsVisibility(visible: Boolean)
+	{
+		panel.quickSettingsOverlayModeRow.root.visibility = if(visible) View.VISIBLE else View.GONE
+		panel.quickSettingsConfigureOverlayButton.visibility = if(visible) View.VISIBLE else View.GONE
+	}
+
+	/** Everything here previews live against the actual on-screen overlay as the user drags the
+	 *  slider or repositions it — nothing is written to Preferences until Save. Cancel (the
+	 *  button, the back button, or tapping outside — all routed through setOnCancelListener so
+	 *  none of them skip this) discards that live preview by re-applying whatever's still
+	 *  persisted, exactly like the panel never having been opened.
+	 *
+	 *  [pendingOpacityPercent] carries the slider's in-progress (not-yet-saved) value across a
+	 *  Move Overlay round-trip — defaulting to the persisted value covers every other entry
+	 *  point (the Configure Overlay button, and Move Overlay's own onDone callback re-reads the
+	 *  live slider position from the dialog being replaced rather than falling back to this
+	 *  default), so the reopened dialog's slider always matches what the overlay is actually
+	 *  rendering rather than snapping back to whatever was last saved. */
+	private fun showConfigureOverlayDialog(pendingOpacityPercent: Int = preferences.performanceOverlayOpacityPercent)
+	{
+		val overlay = activity.findViewById<PerformanceOverlayView>(R.id.performanceOverlay)
+		val binding = DialogConfigureOverlayBinding.inflate(activity.layoutInflater)
+
+		fun updateOpacityLabel(percent: Int)
+		{
+			binding.configureOverlayOpacityLabel.text = activity.getString(R.string.overlay_configure_opacity_label, percent)
+		}
+
+		binding.configureOverlayOpacitySeekBar.progress = pendingOpacityPercent
+		updateOpacityLabel(pendingOpacityPercent)
+		binding.configureOverlayOpacitySeekBar.setOnSeekBarChangeListener(object: SeekBar.OnSeekBarChangeListener
+		{
+			override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean)
+			{
+				updateOpacityLabel(progress)
+				if(fromUser) overlay.setOpacityPercent(progress)
+			}
+			override fun onStartTrackingTouch(seekBar: SeekBar) {}
+			override fun onStopTrackingTouch(seekBar: SeekBar) {}
+		})
+
+		// A plain dialog.dismiss() (what a button click does internally) does NOT fire
+		// setOnCancelListener — only an actual cancel (back press / tap outside) does — so Cancel
+		// needs this called explicitly rather than relying on that listener to cover it too.
+		fun revertAndReopen()
+		{
+			activity.applyPerformanceOverlayCustomization()
+			open()
+		}
+
+		val dialog = activity.alertDialogBuilder()
+			.setTitle(R.string.overlay_configure_title)
+			.setView(binding.root)
+			.setPositiveButton(R.string.action_save) { _, _ ->
+				val streamRoot = activity.findViewById<FrameLayout>(R.id.mainStreamLayout)
+				preferences.performanceOverlayOpacityPercent = binding.configureOverlayOpacitySeekBar.progress
+				preferences.performanceOverlayOffsetXPermille =
+					if(streamRoot.width == 0) 0 else (overlay.translationX * 1000 / streamRoot.width).toInt()
+				preferences.performanceOverlayOffsetYPermille =
+					if(streamRoot.height == 0) 0 else (overlay.translationY * 1000 / streamRoot.height).toInt()
+				open()
+			}
+			.setNegativeButton(R.string.action_cancel) { _, _ -> revertAndReopen() }
+			.setOnCancelListener { revertAndReopen() }
+			.create()
+
+		binding.configureOverlayMoveButton.setOnClickListener {
+			val livePendingOpacity = binding.configureOverlayOpacitySeekBar.progress
+			dialog.dismiss()
+			onMoveOverlay { showConfigureOverlayDialog(livePendingOpacity) }
+		}
+
+		dialog.show()
 	}
 
 	fun handleCaptureKeyEvent(event: KeyEvent): Boolean = capture.handleCaptureKeyEvent(event)

--- a/android/app/src/main/java/com/metallic/chiaki/stream/StreamActivity.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/stream/StreamActivity.kt
@@ -7,14 +7,19 @@ import com.metallic.chiaki.common.ext.alertDialogBuilder
 import com.metallic.chiaki.common.ext.isTv
 import android.Manifest
 import android.app.PictureInPictureParams
+import android.content.res.ColorStateList
 import android.content.res.Configuration
 import android.graphics.Matrix
 import android.os.*
 import android.util.Log
 import android.util.Rational
+import android.util.TypedValue
 import android.view.*
 import android.widget.EditText
+import android.widget.FrameLayout
+import android.widget.PopupWindow
 import androidx.activity.result.contract.ActivityResultContracts
+import com.google.android.material.button.MaterialButton
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
@@ -91,6 +96,13 @@ class StreamActivity : AppCompatActivity(), View.OnSystemUiVisibilityChangeListe
 	 *  then onPictureInPictureModeChanged(false) fires — at that point we check this
 	 *  flag to know we need to shut down the session. */
 	private var activityStopped = false
+
+	/** True for the duration of [startOverlayMoveMode] — pauses the performance overlay's live
+	 *  stat updates (see the overlayData observer) while it's being dragged, so its content isn't
+	 *  also changing while it's being repositioned. Secondary to [startOverlayMoveMode]'s own fix
+	 *  (hosting the overlay in a separate window for the drag) for the disappearing-mid-drag bug,
+	 *  but still worth keeping — you're repositioning it, not reading it, for that brief window. */
+	private var overlayMoveModeActive = false
 
 	/** Saved control state before entering PiP, so we can restore when exiting PiP */
 	private var savedOnScreenControlsEnabled = false
@@ -208,7 +220,8 @@ class StreamActivity : AppCompatActivity(), View.OnSystemUiVisibilityChangeListe
 			},
 			onMoveTouchControl = { control, onSaved ->
 				defaultTouchControlsFragment?.startMoveMode(control, onSaved)
-			}
+			},
+			onMoveOverlay = { onDone -> startOverlayMoveMode(onDone) }
 		)
 
 		// Handle back button — on TV show a disconnect confirmation dialog; on touch,
@@ -283,14 +296,152 @@ class StreamActivity : AppCompatActivity(), View.OnSystemUiVisibilityChangeListe
 		})
 
 		viewModel.overlayData.observe(this, Observer { data ->
-			if (binding.performanceOverlay.isVisible) {
+			if (binding.performanceOverlay.isVisible && !overlayMoveModeActive) {
 				binding.performanceOverlay.updateOverlay(data)
 			}
 		})
 
+		applyPerformanceOverlayCustomization()
+
 		// On TV, the Quick Settings panel is simply never shown — the back-press handler's
 		// isTv() branch below never calls quickSettingsPanel.toggle()/open().
 
+	}
+
+	/** Applies the persisted mode/opacity/position to the performance overlay — called once at
+	 *  connect time, and again by QuickSettingsPanel's Configure Overlay dialog on Cancel to
+	 *  discard whatever was previewed live during that session. Mode and opacity themselves are
+	 *  applied live and immediately by QuickSettingsPanel as the user adjusts them; this is only
+	 *  the "load from Preferences" half. */
+	fun applyPerformanceOverlayCustomization()
+	{
+		val overlay = binding.performanceOverlay
+		val mode = if(viewModel.preferences.performanceOverlayMode == "minimal")
+			PerformanceOverlayView.OverlayMode.MINIMAL
+		else
+			PerformanceOverlayView.OverlayMode.FULL
+		overlay.setMode(mode)
+		overlay.setOpacityPercent(viewModel.preferences.performanceOverlayOpacityPercent)
+		overlay.post {
+			val streamRoot = binding.mainStreamLayout
+			overlay.translationX = streamRoot.width * viewModel.preferences.performanceOverlayOffsetXPermille / 1000f
+			overlay.translationY = streamRoot.height * viewModel.preferences.performanceOverlayOffsetYPermille / 1000f
+		}
+	}
+
+	/** Same drag-to-reposition technique as TouchControlsFragment.startMoveMode, with two
+	 *  differences. First: this doesn't persist on its own "Done" tap — the overlay isn't
+	 *  touch-control chrome the user is done customising the moment they let go of it, it's one
+	 *  setting inside QuickSettingsPanel's Configure Overlay dialog, which still has its own
+	 *  Cancel/Save to get back to. [onDone] just hands control back to that dialog; committing the
+	 *  new position to Preferences (or not) is entirely that dialog's Save/Cancel's call.
+	 *
+	 *  Second: the overlay is temporarily detached from [ActivityStreamBinding.mainStreamLayout]
+	 *  and rehosted as the content of a borderless [PopupWindow] for the duration of the drag,
+	 *  repositioned via [PopupWindow.update] rather than translationX/Y. QuickSettingsPanel's own
+	 *  doc comment explains why: animating a plain View that shares a window with the video
+	 *  GLSurfaceView doesn't composite reliably (confirmed there even with a forced hardware
+	 *  layer) since the SurfaceView's content is composited as a separate hole-punched layer, not
+	 *  in normal Z-order with sibling Views — exactly matching what was seen here (overlay content
+	 *  partially disappearing while being dragged, snapping back once motion stopped). A popup is
+	 *  its own window, composited above the activity's deterministically by the OS, same as why
+	 *  QuickSettingsPanel itself moved into a Dialog. The overlay is reattached to mainStreamLayout
+	 *  at its final position once Done is tapped — it's a static (non-animating) view the rest of
+	 *  the time, which composites over the video fine. */
+	fun startOverlayMoveMode(onDone: () -> Unit)
+	{
+		val overlay = binding.performanceOverlay
+		val streamRoot = binding.mainStreamLayout
+
+		val streamRootLoc = IntArray(2)
+		streamRoot.getLocationOnScreen(streamRootLoc)
+		val overlayLoc = IntArray(2)
+		overlay.getLocationOnScreen(overlayLoc)
+		// overlay.left/top is its natural (untranslated) layout position within streamRoot — the
+		// baseline that translationX/Y (both here and everywhere else this overlay's position is
+		// read/written — see applyPerformanceOverlayCustomization and Configure Overlay's Save) is
+		// relative to. Captured now, before detaching, since left/top are meaningless once removed.
+		val overlayLocalLeft = overlay.left
+		val overlayLocalTop = overlay.top
+
+		streamRoot.removeView(overlay)
+		overlay.translationX = 0f
+		overlay.translationY = 0f
+		overlayMoveModeActive = true
+
+		val popup = PopupWindow(overlay, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT, false).apply {
+			isClippingEnabled = false
+			isTouchable = true
+			isFocusable = false
+			isOutsideTouchable = false
+			elevation = 0f
+		}
+		var popupX = overlayLoc[0]
+		var popupY = overlayLoc[1]
+		popup.showAtLocation(streamRoot, Gravity.NO_GRAVITY, popupX, popupY)
+
+		var downRawX = 0f
+		var downRawY = 0f
+		var startPopupX = popupX
+		var startPopupY = popupY
+
+		overlay.setOnTouchListener { _, event ->
+			when(event.actionMasked)
+			{
+				MotionEvent.ACTION_DOWN ->
+				{
+					downRawX = event.rawX
+					downRawY = event.rawY
+					startPopupX = popupX
+					startPopupY = popupY
+					true
+				}
+				MotionEvent.ACTION_MOVE ->
+				{
+					popupX = startPopupX + (event.rawX - downRawX).toInt()
+					popupY = startPopupY + (event.rawY - downRawY).toInt()
+					popup.update(popupX, popupY, -1, -1)
+					true
+				}
+				else -> true
+			}
+		}
+
+		val accent = TypedValue().let {
+			theme.resolveAttribute(R.attr.pyluxAccent, it, true)
+			it.data
+		}
+		val doneButton = MaterialButton(this).apply {
+			text = getString(R.string.overlay_move_done)
+			setTextColor(android.graphics.Color.WHITE)
+			backgroundTintList = ColorStateList.valueOf(accent)
+		}
+		streamRoot.addView(doneButton, FrameLayout.LayoutParams(
+			ViewGroup.LayoutParams.WRAP_CONTENT,
+			ViewGroup.LayoutParams.WRAP_CONTENT,
+			Gravity.CENTER
+		))
+		doneButton.setOnClickListener {
+			overlay.setOnTouchListener(null)
+			popup.dismiss()
+			// NOT reusing overlay.layoutParams here — PopupWindow's internal decor view mutates
+			// it in place while hosting the content view (observed on-device: it comes back
+			// stretched to match_parent width instead of the original wrap_content), so it's
+			// rebuilt fresh matching activity_stream.xml's declared params for this view exactly.
+			streamRoot.addView(overlay, FrameLayout.LayoutParams(
+				ViewGroup.LayoutParams.WRAP_CONTENT,
+				ViewGroup.LayoutParams.WRAP_CONTENT
+			).apply {
+				gravity = Gravity.TOP or Gravity.START
+				val margin = (8 * resources.displayMetrics.density).toInt()
+				setMargins(margin, margin, margin, margin)
+			})
+			overlay.translationX = (popupX - streamRootLoc[0] - overlayLocalLeft).toFloat()
+			overlay.translationY = (popupY - streamRootLoc[1] - overlayLocalTop).toFloat()
+			overlayMoveModeActive = false
+			streamRoot.removeView(doneButton)
+			onDone()
+		}
 	}
 
 	private val controlsDisposable = CompositeDisposable()

--- a/android/app/src/main/res/drawable/ic_search.xml
+++ b/android/app/src/main/res/drawable/ic_search.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z"/>
+</vector>

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -155,18 +155,6 @@
 
                             </com.google.android.material.card.MaterialCardView>
 
-                            <!-- Own online/offline presence — same bg_friend_online_dot/
-                                 offline_dot drawables and logic as the Friends list (see
-                                 MainActivity.refreshAccountIcon). Hidden until the first
-                                 successful presence fetch so it never shows a guessed state. -->
-                            <View
-                                android:id="@+id/accountStatusDot"
-                                android:layout_width="10dp"
-                                android:layout_height="10dp"
-                                android:layout_gravity="bottom|end"
-                                android:background="@drawable/bg_friend_offline_dot"
-                                android:visibility="gone" />
-
                         </FrameLayout>
 
                     </FrameLayout>

--- a/android/app/src/main/res/layout/dialog_configure_overlay.xml
+++ b/android/app/src/main/res/layout/dialog_configure_overlay.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- No background here — the theme-coloured border is applied to the dialog window itself
+     (see QuickSettingsPanel.showConfigureOverlayDialog), matching dialog_playtime's convention. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="20dp">
+
+    <TextView
+        android:id="@+id/configureOverlayOpacityLabel"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textColor="?attr/pyluxAccent"
+        android:textSize="14sp"
+        android:textStyle="bold" />
+
+    <SeekBar
+        android:id="@+id/configureOverlayOpacitySeekBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:layout_marginBottom="16dp"
+        android:max="100"
+        android:progressTint="?attr/pyluxAccent"
+        android:progressBackgroundTint="@android:color/white"
+        android:thumbTint="?attr/pyluxAccent" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/configureOverlayMoveButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/overlay_configure_move"
+        android:textColor="@android:color/white"
+        app:backgroundTint="?attr/pyluxAccent" />
+
+</LinearLayout>

--- a/android/app/src/main/res/layout/fragment_cloud_play.xml
+++ b/android/app/src/main/res/layout/fragment_cloud_play.xml
@@ -217,7 +217,7 @@
                         android:id="@+id/headerSearchButton"
                         android:layout_width="32dp"
                         android:layout_height="32dp"
-                        android:src="@android:drawable/ic_menu_search"
+                        android:src="@drawable/ic_search"
                         android:background="@drawable/secondary_header_button_bg"
                         android:contentDescription="Search"
                         android:scaleType="centerInside"

--- a/android/app/src/main/res/layout/stream_quick_settings_panel.xml
+++ b/android/app/src/main/res/layout/stream_quick_settings_panel.xml
@@ -224,6 +224,23 @@
             android:paddingBottom="16dp">
 
             <include layout="@layout/item_quick_settings_switch" android:id="@+id/quickSettingsStatsRow" />
+
+            <!-- Both only shown once Performance Overlay (above) is enabled — see
+                 QuickSettingsPanel's updatePerformanceOverlayRowsVisibility. -->
+            <include layout="@layout/item_quick_settings_dropdown" android:id="@+id/quickSettingsOverlayModeRow" />
+
+			<com.google.android.material.button.MaterialButton
+				android:id="@+id/quickSettingsConfigureOverlayButton"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:layout_marginStart="16dp"
+				android:layout_marginEnd="16dp"
+				android:layout_marginBottom="8dp"
+				android:text="@string/quick_settings_configure_overlay"
+				android:textColor="@android:color/white"
+				android:visibility="gone"
+				app:backgroundTint="?attr/pyluxAccent" />
+
             <include layout="@layout/item_quick_settings_switch" android:id="@+id/quickSettingsOscRow" />
 
 			<com.google.android.material.button.MaterialButton

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -212,6 +212,7 @@
     <string name="quick_settings_close">Close</string>
     <string name="quick_settings_current_game">Current game: %s</string>
     <string name="quick_settings_performance_overlay_title">Performance Overlay</string>
+    <string name="quick_settings_overlay_type_title">Overlay Type</string>
     <string name="quick_settings_osc_title">On-Screen Controls</string>
     <string name="touch_controls_customise">Customise</string>
     <string name="touch_controls_customise_button">Customise Button</string>
@@ -398,6 +399,18 @@
 
     <!-- Don't localize these -->
     <string name="preferences_show_performance_overlay_key">show_performance_overlay</string>
+    <string name="preferences_performance_overlay_mode_key">performance_overlay_mode</string>
+    <string name="preferences_performance_overlay_opacity_key">performance_overlay_opacity</string>
+    <string name="preferences_performance_overlay_offset_x_key">performance_overlay_offset_x</string>
+    <string name="preferences_performance_overlay_offset_y_key">performance_overlay_offset_y</string>
+    <string name="quick_settings_overlay_mode_full">Full</string>
+    <string name="quick_settings_overlay_mode_minimal">Minimal</string>
+    <string name="quick_settings_configure_overlay">Configure Overlay</string>
+    <string name="overlay_configure_title">Configure Overlay</string>
+    <string name="overlay_configure_opacity_label">Opacity — %1$d%%</string>
+    <string name="overlay_configure_move">Move Overlay</string>
+    <string name="overlay_move_done">Done</string>
+    <string name="action_save">Save</string>
     <string name="preferences_discovery_enabled_key">discovery_enabled</string>
     <string name="preferences_on_screen_controls_enabled_key">on_screen_controls_enabled</string>
     <string name="preferences_touchpad_only_enabled_key">touchpad_only_enabled</string>


### PR DESCRIPTION
…e FSR shader locations

Adds Full/Minimal overlay view modes (Minimal by default), a Configure Overlay dialog with opacity control and drag-to-reposition, fixing the overlay disappearing while dragged and stretching after save. Also removes the main menu profile status dot, fixes the search icon's color to match the other header icons, and caches FSR shader uniform/ attribute locations instead of re-resolving them every frame.