### PR TITLE
Add Adaptive Frame Pacing toggle for all session types

### DIFF
--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RELEASE_NOTES: |-
-        - Documentation and release-workflow update only — no app functionality changes in this release.
+        - Added an "Adaptive Frame Pacing" toggle (Settings, off by default) that smooths out uneven frame delivery on unstable connections: it widens the presentation buffer based on recently-measured network jitter instead of using a fixed value, and proactively drops frames that arrive in a burst rather than letting latency build up. Applies to Remote Play, Game Library, and Game Catalog.
 
     steps:
       - name: Checkout repo

--- a/android/app/src/main/cpp/chiaki-jni.c
+++ b/android/app/src/main/cpp/chiaki-jni.c
@@ -490,6 +490,11 @@ JNIEXPORT void JNICALL JNI_FCN(sessionCreate)(JNIEnv *env, jobject obj, jobject 
 
 	connect_info.video_profile_auto_downgrade = true;
 
+	// Applies to every session type — Android video-decoder presentation concern only, not
+	// part of the core ChiakiConnectInfo/session protocol, so it's read straight into a local
+	// rather than connect_info.
+	bool adaptive_frame_pacing_enabled = E->GetBooleanField(env, connect_info_obj, E->GetFieldID(env, connect_info_class, "adaptiveFramePacingEnabled", "Z"));
+
 	// Auto-registration field (for PSN remote registration)
 	jboolean auto_regist = E->GetBooleanField(env, connect_info_obj, E->GetFieldID(env, connect_info_class, "autoRegist", "Z"));
 	connect_info.auto_regist = auto_regist;
@@ -597,7 +602,8 @@ JNIEXPORT void JNICALL JNI_FCN(sessionCreate)(JNIEnv *env, jobject obj, jobject 
 	session->metrics_drops = 0;
 	err = android_chiaki_video_decoder_init(&session->video_decoder, log, connect_info.video_profile.width, connect_info.video_profile.height,
 			(int32_t)connect_info.video_profile.max_fps,
-			connect_info.ps5 ? connect_info.video_profile.codec : CHIAKI_CODEC_H264);
+			connect_info.ps5 ? connect_info.video_profile.codec : CHIAKI_CODEC_H264,
+			adaptive_frame_pacing_enabled);
 	if(err != CHIAKI_ERR_SUCCESS)
 	{
 		free(session);

--- a/android/app/src/main/cpp/video-decoder.c
+++ b/android/app/src/main/cpp/video-decoder.c
@@ -28,7 +28,7 @@ static int64_t now_us()
 static void *android_chiaki_video_decoder_output_thread_func(void *user);
 static void *android_chiaki_video_decoder_input_thread_func(void *user);
 
-ChiakiErrorCode android_chiaki_video_decoder_init(AndroidChiakiVideoDecoder *decoder, ChiakiLog *log, int32_t target_width, int32_t target_height, int32_t target_fps, ChiakiCodec codec)
+ChiakiErrorCode android_chiaki_video_decoder_init(AndroidChiakiVideoDecoder *decoder, ChiakiLog *log, int32_t target_width, int32_t target_height, int32_t target_fps, ChiakiCodec codec, bool adaptive_frame_pacing_enabled)
 {
 	decoder->log = log;
 	decoder->codec = NULL;
@@ -40,6 +40,7 @@ ChiakiErrorCode android_chiaki_video_decoder_init(AndroidChiakiVideoDecoder *dec
 	decoder->output_frames_total = 0;
 	decoder->next_render_ns = 0;
 	decoder->input_timeouts = 0;
+	decoder->adaptive_frame_pacing_enabled = adaptive_frame_pacing_enabled;
 
 	decoder->frame_queue_head = 0;
 	decoder->frame_queue_tail = 0;
@@ -160,6 +161,8 @@ void android_chiaki_video_decoder_set_surface(AndroidChiakiVideoDecoder *decoder
 		CHIAKI_LOGI(decoder->log, "Set ANativeWindow frame rate to %d fps", decoder->target_fps);
 	}
 #endif
+
+	CHIAKI_LOGI(decoder->log, "Adaptive Frame Pacing: %s", decoder->adaptive_frame_pacing_enabled ? "enabled" : "disabled");
 
 	const char *mime = chiaki_codec_is_h265(decoder->target_codec) ? "video/hevc" : "video/avc";
 	CHIAKI_LOGI(decoder->log, "Initializing decoder with mime %s", mime);
@@ -367,6 +370,13 @@ static void *android_chiaki_video_decoder_output_thread_func(void *user)
 	int64_t min_headroom_ns   = INT64_MAX; // minimum raw grid headroom per bucket
 	int64_t ema_inter_frame_ns = vsync_period_ns; // EMA of actual inter-frame interval
 
+	// Adaptive Frame Pacing: continuously-updated jitter magnitude (independent of the
+	// short/long bucket counts above, which reset every second) used to size the
+	// presentation buffer dynamically instead of a fixed constant. Computed unconditionally
+	// (cheap) but only changes presentation behavior when adaptive_frame_pacing_enabled.
+	int64_t ema_jitter_ns    = 0;
+	int     adaptive_dropped = 0; // frames dropped this second to thin a burst
+
 	decoder->next_render_ns = 0;
 
 	while(1)
@@ -392,6 +402,9 @@ static void *android_chiaki_video_decoder_output_thread_func(void *user)
 						long_intervals++;
 					else
 						ema_inter_frame_ns = (ema_inter_frame_ns * 7 + delta_ns) / 8;
+
+					int64_t deviation_ns = delta_ns > vsync_period_ns ? delta_ns - vsync_period_ns : vsync_period_ns - delta_ns;
+					ema_jitter_ns = (ema_jitter_ns * 7 + deviation_ns) / 8;
 				}
 				last_frame_ns = now_ns;
 
@@ -408,6 +421,12 @@ static void *android_chiaki_video_decoder_output_thread_func(void *user)
 					CHIAKI_LOGI(decoder->log, "VIDEO_FRAME_TIMING fps=%.1f short=%d long=%d in_tout=%d min_hdm=%d",
 						bucket_frames * 1e9f / (float)elapsed_ns,
 						short_intervals, long_intervals, new_timeouts, min_hdm_ms);
+					if(decoder->adaptive_frame_pacing_enabled)
+					{
+						CHIAKI_LOGI(decoder->log, "ADAPTIVE_PACING jitter_ms=%.1f dropped=%d",
+							(double)ema_jitter_ns / 1000000.0, adaptive_dropped);
+						adaptive_dropped = 0;
+					}
 					bucket_start_ns   = now_ns;
 					bucket_frames     = 0;
 					short_intervals   = 0;
@@ -421,29 +440,55 @@ static void *android_chiaki_video_decoder_output_thread_func(void *user)
 				//
 				// 2x vsync (33ms at 60fps) baseline minimises display-side input latency.
 				// Cap at 8x vsync (133ms at 60fps) as a safety net for extreme jitter bursts.
-				const int64_t baseline_ns = 2 * vsync_period_ns;
-				const int64_t cap_ns      = 8 * vsync_period_ns;
+				// Adaptive Frame Pacing (when enabled) scales the baseline up with recently
+				// observed jitter (ema_jitter_ns above) instead of using the fixed value, and
+				// proactively drops frames that arrive well ahead of schedule during a burst —
+				// see below — rather than queueing them further into the future and letting
+				// latency creep up until a hard cap-reset is needed.
+				int64_t baseline_ns = 2 * vsync_period_ns;
+				if(decoder->adaptive_frame_pacing_enabled)
+				{
+					const int64_t adaptive_max_ns = 8 * vsync_period_ns;
+					int64_t adaptive_baseline_ns = baseline_ns + ema_jitter_ns * 2;
+					baseline_ns = adaptive_baseline_ns > adaptive_max_ns ? adaptive_max_ns : adaptive_baseline_ns;
+				}
+				const int64_t cap_ns = 4 * baseline_ns;
 				int64_t render_ns = decoder->next_render_ns;
 				int64_t headroom_ns = render_ns - now_ns;
 				// Skip headroom recording on the very first frame (next_render_ns==0
 				// gives a boot-time-sized negative that pollutes the min_hdm log).
 				if(decoder->next_render_ns > 0 && headroom_ns < min_headroom_ns)
 					min_headroom_ns = headroom_ns;
-				if(headroom_ns <= 1000000LL || headroom_ns > cap_ns)
-					render_ns = now_ns + baseline_ns;
 
-				AMediaCodec_releaseOutputBufferAtTime(decoder->codec, (size_t)status, render_ns);
-				// Target baseline headroom: when above baseline use vsync_period so excess
-				// bleeds off naturally; when at/below baseline use EMA (>= vsync_period) to
-				// counteract systematic drain if server delivers slightly below 60fps.
-				// This keeps headroom near baseline and prevents cap-overflow resets, which
-				// cause timestamp inversions (newer frame scheduled before older frame in
-				// SurfaceFlinger queue → visible stutter every ~13s).
-				int64_t advance_ns = (headroom_ns > baseline_ns)
-					? vsync_period_ns
-					: (ema_inter_frame_ns > vsync_period_ns ? ema_inter_frame_ns : vsync_period_ns);
-				decoder->next_render_ns = render_ns + advance_ns;
-				decoder->output_frames_total++;
+				// Adaptive Frame Pacing: this frame arrived as part of a burst and the
+				// schedule is already comfortably ahead — drop it instead of queueing yet
+				// another vsync_period_ns onto next_render_ns, which would otherwise let
+				// presentation latency creep up through the whole burst until the cap-reset
+				// below eventually fires (itself a visible stutter).
+				if(decoder->adaptive_frame_pacing_enabled && decoder->next_render_ns > 0
+					&& headroom_ns > baseline_ns + 2 * vsync_period_ns)
+				{
+					AMediaCodec_releaseOutputBuffer(decoder->codec, (size_t)status, false);
+					adaptive_dropped++;
+				}
+				else
+				{
+					if(headroom_ns <= 1000000LL || headroom_ns > cap_ns)
+						render_ns = now_ns + baseline_ns;
+
+					AMediaCodec_releaseOutputBufferAtTime(decoder->codec, (size_t)status, render_ns);
+					// Target baseline headroom: when above baseline use vsync_period so excess
+					// bleeds off naturally; when at/below baseline use EMA (>= vsync_period) to
+					// counteract systematic drain if server delivers slightly below 60fps.
+					// This keeps headroom near baseline and prevents cap-overflow resets, which
+					// cause timestamp inversions (newer frame scheduled before older frame in
+					// SurfaceFlinger queue → visible stutter every ~13s).
+					int64_t advance_ns = (headroom_ns > baseline_ns)
+						? vsync_period_ns
+						: (ema_inter_frame_ns > vsync_period_ns ? ema_inter_frame_ns : vsync_period_ns);
+					decoder->next_render_ns = render_ns + advance_ns;
+					decoder->output_frames_total++;
+				}
 			}
 			else
 			{

--- a/android/app/src/main/cpp/video-decoder.h
+++ b/android/app/src/main/cpp/video-decoder.h
@@ -36,6 +36,12 @@ typedef struct android_chiaki_video_decoder_t
 	int64_t next_render_ns;
 	volatile int32_t input_timeouts;
 
+	// Applies to every session type. When true, the output thread scales its presentation
+	// buffer to recently-observed jitter (instead of a fixed baseline) and proactively drops
+	// frames that arrive well ahead of schedule during a burst. See
+	// android_chiaki_video_decoder_output_thread_func in video-decoder.c.
+	bool adaptive_frame_pacing_enabled;
+
 	// Producer-consumer frame queue: stream thread enqueues, input thread submits to codec
 	AndroidChiakiVideoDecoderFrame frame_queue[ANDROID_CHIAKI_VIDEO_DECODER_FRAME_QUEUE_CAPACITY];
 	size_t frame_queue_head;
@@ -48,7 +54,7 @@ typedef struct android_chiaki_video_decoder_t
 	bool input_thread_running;
 } AndroidChiakiVideoDecoder;
 
-ChiakiErrorCode android_chiaki_video_decoder_init(AndroidChiakiVideoDecoder *decoder, ChiakiLog *log, int32_t target_width, int32_t target_height, int32_t target_fps, ChiakiCodec codec);
+ChiakiErrorCode android_chiaki_video_decoder_init(AndroidChiakiVideoDecoder *decoder, ChiakiLog *log, int32_t target_width, int32_t target_height, int32_t target_fps, ChiakiCodec codec, bool adaptive_frame_pacing_enabled);
 void android_chiaki_video_decoder_fini(AndroidChiakiVideoDecoder *decoder);
 void android_chiaki_video_decoder_set_surface(AndroidChiakiVideoDecoder *decoder, JNIEnv *env, jobject surface);
 bool android_chiaki_video_decoder_video_sample(uint8_t *buf, size_t buf_size, int32_t frames_lost, bool frame_recovered, void *user);

--- a/android/app/src/main/java/com/metallic/chiaki/cloudplay/CloudConnectInfoBuilder.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/cloudplay/CloudConnectInfoBuilder.kt
@@ -51,6 +51,7 @@ object CloudConnectInfoBuilder
 			registKey = ByteArray(0x10), // Empty for cloud (not used)
 			morning = ByteArray(0x10), // Empty for cloud (not used)
 			videoProfile = videoProfile,
+			adaptiveFramePacingEnabled = preferences.adaptiveFramePacingEnabled,
 			serviceType = session.serviceType,
 			cloudGamePlatform = session.platform,
 			cloudLaunchSpec = session.launchSpec,

--- a/android/app/src/main/java/com/metallic/chiaki/common/Preferences.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/common/Preferences.kt
@@ -218,6 +218,13 @@ class Preferences(context: Context)
 		get() = sharedPreferences.getBoolean(pipEnabledKey, true)
 		set(value) { sharedPreferences.edit().putBoolean(pipEnabledKey, value).apply() }
 
+	// Applies to every session type (Remote Play, PS Cloud, Game Catalog) - see
+	// AndroidChiakiVideoDecoder's adaptive_frame_pacing_enabled in video-decoder.c.
+	val adaptiveFramePacingEnabledKey get() = resources.getString(R.string.preferences_adaptive_frame_pacing_key)
+	var adaptiveFramePacingEnabled
+		get() = sharedPreferences.getBoolean(adaptiveFramePacingEnabledKey, false)
+		set(value) { sharedPreferences.edit().putBoolean(adaptiveFramePacingEnabledKey, value).apply() }
+
 	val casSharpeningEnabledKey get() = resources.getString(R.string.preferences_cas_sharpening_enabled_key)
 	var casSharpeningEnabled
 		get() = sharedPreferences.getBoolean(casSharpeningEnabledKey, false)

--- a/android/app/src/main/java/com/metallic/chiaki/lib/Chiaki.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/lib/Chiaki.kt
@@ -70,6 +70,9 @@ data class ConnectInfo(
 	val registKey: ByteArray,
 	val morning: ByteArray,
 	val videoProfile: ConnectVideoProfile,
+	// Applies to every session type (Remote Play, PS Cloud, Game Catalog) — see
+	// AndroidChiakiVideoDecoder.adaptive_frame_pacing_enabled in video-decoder.c.
+	val adaptiveFramePacingEnabled: Boolean = false,
 	// Cloud streaming fields (optional, null for remote play)
 
 	val serviceType: String? = null, // "psnow" or "pscloud"

--- a/android/app/src/main/java/com/metallic/chiaki/main/RemotePlayFragment.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/main/RemotePlayFragment.kt
@@ -335,7 +335,15 @@ class RemotePlayFragment : Fragment()
 		if(registeredHost != null)
 		{
 			fun connect() {
-				val connectInfo = ConnectInfo(host.isPS5, host.host, registeredHost.rpRegistKey, registeredHost.rpKey, Preferences(requireContext()).videoProfile)
+				val prefs = Preferences(requireContext())
+				val connectInfo = ConnectInfo(
+					ps5 = host.isPS5,
+					host = host.host,
+					registKey = registeredHost.rpRegistKey,
+					morning = registeredHost.rpKey,
+					videoProfile = prefs.videoProfile,
+					adaptiveFramePacingEnabled = prefs.adaptiveFramePacingEnabled
+				)
 				Intent(requireContext(), StreamActivity::class.java).let {
 					it.putExtra(StreamActivity.EXTRA_CONNECT_INFO, connectInfo)
 					startActivity(it)
@@ -523,6 +531,7 @@ class RemotePlayFragment : Fragment()
 				registKey = registeredHost.rpRegistKey,
 				morning = registeredHost.rpKey,
 				videoProfile = prefs.videoProfile,
+				adaptiveFramePacingEnabled = prefs.adaptiveFramePacingEnabled,
 				duid = host.duid,
 				psnToken = prefs.psnAuthToken,
 				psnAccountId = prefs.psnAccountId

--- a/android/app/src/main/java/com/metallic/chiaki/regist/PsnAutoRegistration.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/regist/PsnAutoRegistration.kt
@@ -129,6 +129,7 @@ class PsnAutoRegistration(
 					registKey = ByteArray(CHIAKI_SESSION_AUTH_SIZE),
 					morning = ByteArray(CHIAKI_KEY_SIZE),
 					videoProfile = prefs.videoProfile,
+					adaptiveFramePacingEnabled = prefs.adaptiveFramePacingEnabled,
 					duid = duid,
 					psnToken = token,
 					psnAccountId = prefs.psnAccountId,

--- a/android/app/src/main/java/com/metallic/chiaki/settings/SettingsFragment.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/settings/SettingsFragment.kt
@@ -41,6 +41,7 @@ class DataStore(val preferences: Preferences): PreferenceDataStore()
 		preferences.casSharpeningEnabledKey -> preferences.casSharpeningEnabled
 		preferences.fsrEnabledKey -> preferences.fsrEnabled
 		preferences.fsrUpscalingEnabledKey -> preferences.fsrUpscalingEnabled
+		preferences.adaptiveFramePacingEnabledKey -> preferences.adaptiveFramePacingEnabled
 		else -> defValue
 	}
 
@@ -56,6 +57,7 @@ class DataStore(val preferences: Preferences): PreferenceDataStore()
 			preferences.casSharpeningEnabledKey -> preferences.casSharpeningEnabled = value
 			preferences.fsrEnabledKey -> preferences.fsrEnabled = value
 			preferences.fsrUpscalingEnabledKey -> preferences.fsrUpscalingEnabled = value
+			preferences.adaptiveFramePacingEnabledKey -> preferences.adaptiveFramePacingEnabled = value
 		}
 	}
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -167,6 +167,8 @@
     <string name="preferences_codec_title_h265">H265 (Gen 5 only)</string>
     <string name="preferences_pip_enabled_title">Picture-in-Picture</string>
     <string name="preferences_pip_enabled_summary">Enable PiP mode when minimizing during streaming (Android 8.0+)</string>
+    <string name="preferences_adaptive_frame_pacing_title">Adaptive Frame Pacing</string>
+    <string name="preferences_adaptive_frame_pacing_summary">Smooths out uneven frame delivery by adjusting how far ahead frames are buffered and occasionally dropping bunched frames when the network jitters. Adds a little latency in exchange for steadier motion on unstable connections. Applies to Remote Play, Game Library and Game Catalog.</string>
     <string name="preferences_swap_cross_moon_title">Swap Cross/Moon and Box/Pyramid Buttons</string>
     <string name="preferences_swap_cross_moon_summary">Swap face buttons if default mapping is incorrect (e.g. for 8BitDo controllers)</string>
     <string name="preferences_microphone_enabled_title">Microphone (Remote Play only)</string>
@@ -434,6 +436,7 @@
     <string name="preferences_cloud_resolution_psnow_key">cloud_resolution_psnow</string>
     <string name="preferences_cloud_resolution_pscloud_key">cloud_resolution_pscloud</string>
     <string name="preferences_pip_enabled_key">pip_enabled</string>
+    <string name="preferences_adaptive_frame_pacing_key">adaptive_frame_pacing_enabled</string>
     <string name="preferences_cas_sharpening_enabled_key">cas_sharpening_enabled</string>
     <string name="preferences_cas_sharpening_level_key">cas_sharpening_level</string>
     <string name="preferences_fsr_enabled_key">fsr_enabled</string>

--- a/android/app/src/main/res/xml/preferences.xml
+++ b/android/app/src/main/res/xml/preferences.xml
@@ -94,6 +94,13 @@
             app:icon="@drawable/ic_resolution"/>
 
         <SwitchPreference
+            app:key="@string/preferences_adaptive_frame_pacing_key"
+            app:title="@string/preferences_adaptive_frame_pacing_title"
+            app:summary="@string/preferences_adaptive_frame_pacing_summary"
+            app:defaultValue="false"
+            app:icon="@drawable/ic_fps"/>
+
+        <SwitchPreference
             app:key="@string/preferences_log_verbose_key"
             app:title="@string/preferences_log_verbose_title"
             app:summary="@string/preferences_log_verbose_summary"


### PR DESCRIPTION
The vsync-grid scheduler's presentation buffer was a fixed 2x vsync period (33ms at 60fps), which real-world network jitter (observed RTT swings of several hundred ms against Sony's cloud servers) can exceed, causing visible stutter. Adaptive Frame Pacing (Settings, off by default) makes this dynamic instead: it tracks a continuously-updated jitter EMA and scales the buffer up to 8x vsync period based on recently-observed conditions, and proactively drops frames that arrive well ahead of schedule during a burst rather than letting presentation latency creep up until a hard cap-reset (itself a stutter). Applies to Remote Play, PS Cloud, and Game Catalog via the shared native decoder path.