### PR TITLE
Fix clipped analog sticks; add in-stream Adaptive Frame Pacing toggle

### DIFF
--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -16,13 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RELEASE_NOTES: |-
-        - Added an "Adaptive Frame Pacing" toggle (Settings, off by default) that smooths out uneven frame delivery on unstable connections: it widens the presentation buffer based on recently-measured network jitter instead of using a fixed value, and proactively drops frames that arrive in a burst rather than letting latency build up. Applies to Remote Play, Game Library, and Game Catalog.
-        - Added an "App Language" setting (Settings > Appearance) that lets you switch CloudPad's own interface to one of 10 languages (English UK/US, German, French, Finnish, Italian, Spanish, Dutch, Brazilian Portuguese, Japanese, Korean) or follow your device's language, independent of your system language.
-        - Extended App Language coverage to text that was previously always in English regardless of the selected language — dialogs, toasts, and status messages across Remote Play registration, Cloud Play, trophies, and console list screens now translate correctly too.
-        - Fixed more App Language gaps that only lived in screen layouts rather than code: the PS3 Catalog/PS4 Catalog/PS5 Library tab labels, the "No games found" and "Refresh Games List" text, the cloud allocation screen's progress message and Cancel button, the Trophies/Friends screen headers, the License Agreement screen, the startup disclaimer, and the trophy rarity badges (Bronze/Silver/Gold/Platinum) all now translate correctly.
-        - Fixed the friends list's status text ("Playing X", "Online", "Busy", "Last online...", "Offline") and friends/messaging error messages, which were still always in English regardless of the selected App Language.
-        - Fixed the Controller Remap screen (Settings and the in-stream Quick Settings panel), the PSN sign-in instructions, the trophy-unlock popup's rarity badge, and various trophy-comparison and stream-restart error messages, which were still always in English regardless of the selected App Language.
-        - Fixed PS Cloud's datacenter-selection request to include every tested datacenter's ping result (not just the one picked), matching what the server expects for a complete network picture.
+        - Fixed on-screen analog sticks rendering with flattened top/bottom edges instead of a full circle on some phone screen aspect ratios, where the stick's layout region ended up shorter than its visual size.
+        - Added an "Adaptive Frame Pacing" toggle to the in-stream Quick Settings panel (Session tab, under Bitrate) alongside the existing Settings screen toggle. Since it only takes effect on a fresh session, changing it here requires hitting Apply like Resolution/Bitrate/Codec do, and the performance overlay's new "AFP" status line only updates once that restart actually completes.
 
     steps:
       - name: Checkout repo

--- a/android/app/src/main/java/com/metallic/chiaki/stream/PerformanceOverlayView.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/stream/PerformanceOverlayView.kt
@@ -22,7 +22,8 @@ class PerformanceOverlayView @JvmOverloads constructor(
 ) : LinearLayout(context, attrs, defStyleAttr) {
 
     /** FULL is every metric (the original view); MINIMAL is just the numbers most people
-     *  actually glance at mid-session — FPS, Bitrate, Resolution, Video Loss, Drops and Ping. */
+     *  actually glance at mid-session — FPS, Bitrate, Resolution, Video Loss, Drops, Ping and
+     *  Adaptive Frame Pacing status. */
     enum class OverlayMode { FULL, MINIMAL }
 
     private val headerView: TextView
@@ -41,6 +42,7 @@ class PerformanceOverlayView @JvmOverloads constructor(
     private val labelDT = metricRow("DT")
     private val labelVL = metricRow("VL")
     private val labelDrops = metricRow("Drops")
+    private val labelAfp = metricRow("AFP")
 
     init {
         orientation = VERTICAL
@@ -85,6 +87,7 @@ class PerformanceOverlayView @JvmOverloads constructor(
         qualityCol.addView(labelDT)
         qualityCol.addView(labelVL)
         qualityCol.addView(labelDrops)
+        qualityCol.addView(labelAfp)
 
         columns.addView(
             latencyCol,
@@ -274,6 +277,14 @@ class PerformanceOverlayView @JvmOverloads constructor(
         labelVL.setTextColor(lossColor)
 
         labelDrops.text = String.format(Locale.US, "%-5s %-5d", "Drops", m.drops)
+
+        labelAfp.text = String.format(
+            Locale.US, "%-5s %-5s", "AFP",
+            if (data.adaptiveFramePacingEnabled) "Enabled" else "Disabled"
+        )
+        labelAfp.setTextColor(
+            if (data.adaptiveFramePacingEnabled) Color.rgb(0, 220, 100) else Color.argb(180, 255, 255, 255)
+        )
 
         sparklineView.setData(data.fpsHistory)
     }

--- a/android/app/src/main/java/com/metallic/chiaki/stream/QuickSettingsPanel.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/stream/QuickSettingsPanel.kt
@@ -78,6 +78,7 @@ import com.pylux.stream.R
 import com.pylux.stream.databinding.ItemQuickSettingsDropdownBinding
 import com.pylux.stream.databinding.ItemQuickSettingsEdittextBinding
 import com.pylux.stream.databinding.ItemQuickSettingsSeekbarBinding
+import com.pylux.stream.databinding.ItemQuickSettingsSwitchBinding
 import com.pylux.stream.databinding.DialogConfigureOverlayBinding
 import com.pylux.stream.databinding.DialogTouchControlsCustomiseBinding
 import com.pylux.stream.databinding.StreamQuickSettingsPanelBinding
@@ -283,13 +284,15 @@ class QuickSettingsPanel(
 		val resolution: Preferences.Resolution,
 		val fps: Preferences.FPS,
 		val bitrate: Int?,
-		val codec: Preferences.Codec
+		val codec: Preferences.Codec,
+		val adaptiveFramePacingEnabled: Boolean
 	)
 
 	private data class CloudSettingsSnapshot(
 		val resolution: Int,
 		val datacenter: String,
-		val bitrateKbps: Int
+		val bitrateKbps: Int,
+		val adaptiveFramePacingEnabled: Boolean
 	)
 
 	/** Snapshot of the settings the live stream actually last (re)started with, i.e. what's
@@ -1235,6 +1238,14 @@ class QuickSettingsPanel(
 			updateSessionApplyVisibility()
 		}
 
+		sessionRowControls += addSwitchRow(
+			container, R.string.preferences_adaptive_frame_pacing_title,
+			currentValue = preferences.adaptiveFramePacingEnabled
+		) { isChecked ->
+			pendingRemotePlaySettings = pendingRemotePlaySettings?.copy(adaptiveFramePacingEnabled = isChecked)
+			updateSessionApplyVisibility()
+		}
+
 		sessionRowControls += addDropdownRow(
 			container, R.string.preferences_codec_title,
 			entries = Preferences.codecAll.map { activity.getString(it.title) },
@@ -1297,6 +1308,14 @@ class QuickSettingsPanel(
 			pendingCloudSettings = pendingCloudSettings?.copy(bitrateKbps = valueMbps * 1000)
 			updateSessionApplyVisibility()
 		}
+
+		sessionRowControls += addSwitchRow(
+			container, R.string.preferences_adaptive_frame_pacing_title,
+			currentValue = preferences.adaptiveFramePacingEnabled
+		) { isChecked ->
+			pendingCloudSettings = pendingCloudSettings?.copy(adaptiveFramePacingEnabled = isChecked)
+			updateSessionApplyVisibility()
+		}
 	}
 
 	/** Writes this tab's pending, not-yet-persisted edits into [preferences] — see
@@ -1312,6 +1331,7 @@ class QuickSettingsPanel(
 				preferences.fps = pending.fps
 				preferences.bitrate = pending.bitrate
 				preferences.codec = pending.codec
+				preferences.adaptiveFramePacingEnabled = pending.adaptiveFramePacingEnabled
 			}
 			StreamSessionType.CATALOG_PSNOW, StreamSessionType.LIBRARY_PSCLOUD -> pendingCloudSettings?.let { pending ->
 				if(sessionType == StreamSessionType.LIBRARY_PSCLOUD)
@@ -1326,6 +1346,7 @@ class QuickSettingsPanel(
 					preferences.setCloudDatacenterPsnow(pending.datacenter)
 					preferences.setCloudBitratePsnow(pending.bitrateKbps)
 				}
+				preferences.adaptiveFramePacingEnabled = pending.adaptiveFramePacingEnabled
 			}
 		}
 	}
@@ -1334,7 +1355,8 @@ class QuickSettingsPanel(
 		resolution = preferences.resolution,
 		fps = preferences.fps,
 		bitrate = preferences.bitrate,
-		codec = preferences.codec
+		codec = preferences.codec,
+		adaptiveFramePacingEnabled = preferences.adaptiveFramePacingEnabled
 	)
 
 	/** Reads whichever of the Catalog (PSNow)/Library (PSCloud) preference keys applies to this
@@ -1346,7 +1368,8 @@ class QuickSettingsPanel(
 		return CloudSettingsSnapshot(
 			resolution = if(isLibrary) preferences.getCloudResolutionPscloud() else preferences.getCloudResolutionPsnow(),
 			datacenter = if(isLibrary) preferences.getCloudDatacenterPscloud() else preferences.getCloudDatacenterPsnow(),
-			bitrateKbps = if(isLibrary) preferences.getCloudBitratePscloud() else preferences.getCloudBitratePsnow()
+			bitrateKbps = if(isLibrary) preferences.getCloudBitratePscloud() else preferences.getCloudBitratePsnow(),
+			adaptiveFramePacingEnabled = preferences.adaptiveFramePacingEnabled
 		)
 	}
 
@@ -1508,6 +1531,21 @@ class QuickSettingsPanel(
 		})
 		addFocusHighlight(row.quickSettingsSeekBar, pyluxAccentColor)
 		return row.quickSettingsSeekBar
+	}
+
+	private fun addSwitchRow(
+		container: LinearLayout,
+		labelRes: Int,
+		currentValue: Boolean,
+		onChanged: (Boolean) -> Unit
+	): View
+	{
+		val row = ItemQuickSettingsSwitchBinding.inflate(activity.layoutInflater, container, true)
+		row.quickSettingsRowLabel.text = activity.getString(labelRes)
+		row.quickSettingsRowSwitch.isChecked = currentValue
+		row.quickSettingsRowSwitch.setOnCheckedChangeListener { _, isChecked -> onChanged(isChecked) }
+		addFocusHighlight(row.quickSettingsRowSwitch, pyluxAccentColor)
+		return row.quickSettingsRowSwitch
 	}
 
 	private fun addEditTextRow(

--- a/android/app/src/main/java/com/metallic/chiaki/stream/StreamViewModel.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/stream/StreamViewModel.kt
@@ -28,7 +28,8 @@ data class OverlayData(
 	val jitter: Double,
 	val smoothedPing: Double,
 	val header: String,
-	val fpsHistory: List<Float>
+	val fpsHistory: List<Float>,
+	val adaptiveFramePacingEnabled: Boolean
 )
 
 /** State of an in-stream settings-driven session restart (Quick Settings panel's Apply button).
@@ -139,7 +140,13 @@ class StreamViewModel(
 							jitter = jitter,
 							smoothedPing = smoothedPing,
 							header = header,
-							fpsHistory = fpsHistory.toList()
+							fpsHistory = fpsHistory.toList(),
+							// session.connectInfo (not preferences directly) so this only flips once
+							// a restart has actually swapped in the new session — not the instant a
+							// pending Quick Settings change is applied. See
+							// StreamSession.restartWithNewConnectInfo, which reassigns connectInfo
+							// right before the new session is actually created.
+							adaptiveFramePacingEnabled = session.connectInfo.adaptiveFramePacingEnabled
 						)
 					)
 				}
@@ -214,7 +221,10 @@ class StreamViewModel(
 	 *  for the full story (a real, on-device crash without this). */
 	fun restartRemotePlaySession() {
 		_sessionRestartState.value = SessionRestartState.InProgress(application.getString(R.string.quick_settings_session_restarting))
-		val newConnectInfo = session.connectInfo.copy(videoProfile = preferences.videoProfile)
+		val newConnectInfo = session.connectInfo.copy(
+			videoProfile = preferences.videoProfile,
+			adaptiveFramePacingEnabled = preferences.adaptiveFramePacingEnabled
+		)
 		session.restartWithNewConnectInfo(newConnectInfo, onResuming = {
 			_sessionRestartState.value = SessionRestartState.Idle
 		})

--- a/android/app/src/main/java/com/metallic/chiaki/touchcontrols/AnalogStickView.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/touchcontrols/AnalogStickView.kt
@@ -66,6 +66,15 @@ class AnalogStickView @JvmOverloads constructor(
 		}
 	}
 
+	/** The stick's base drawable is always given a square bounding box (same radius on both
+	 *  axes), so on a layout region shorter than the stick's natural diameter — e.g. a wide/
+	 *  short-aspect-ratio phone where the D-Pad's fixed height leaves less room below it than
+	 *  usual — the view's own canvas doesn't have enough vertical space to show the full
+	 *  circle, and it renders with its top and bottom edges flattened off instead of round.
+	 *  Clamping to the view's own half-width/half-height keeps the drawn circle a true circle
+	 *  (just a smaller one) on any screen, instead of a squashed oval. */
+	private fun visibleCircleRadius() = minOf(radius + handleRadius, width / 2f, height / 2f)
+
 	override fun onDraw(canvas: Canvas)
 	{
 		super.onDraw(canvas)
@@ -73,13 +82,14 @@ class AnalogStickView @JvmOverloads constructor(
 		val center = center
 		if(center != null)
 		{
-			val circleRadius = radius + handleRadius
+			val circleRadius = visibleCircleRadius()
 			drawableBase?.setBounds((center.x - circleRadius).toInt(), (center.y - circleRadius).toInt(), (center.x + circleRadius).toInt(), (center.y + circleRadius).toInt())
 			drawableBase?.draw(canvas)
 
+			val handleDrawRadius = minOf(handleRadius, circleRadius)
 			val handleX = center.x + handlePosition.x * radius
 			val handleY = center.y + handlePosition.y * radius
-			drawableHandle?.setBounds((handleX - handleRadius).toInt(), (handleY - handleRadius).toInt(), (handleX + handleRadius).toInt(),(handleY + handleRadius).toInt())
+			drawableHandle?.setBounds((handleX - handleDrawRadius).toInt(), (handleY - handleDrawRadius).toInt(), (handleX + handleDrawRadius).toInt(),(handleY + handleDrawRadius).toInt())
 			drawableHandle?.draw(canvas)
 		}
 	}
@@ -143,7 +153,7 @@ class AnalogStickView @JvmOverloads constructor(
 		val center = center ?: return false
 		val dx = x - center.x
 		val dy = y - center.y
-		val visibleRadius = radius + handleRadius
+		val visibleRadius = visibleCircleRadius()
 		return dx * dx + dy * dy <= visibleRadius * visibleRadius
 	}
 }


### PR DESCRIPTION
AnalogStickView always gave its base drawable a square bounding box sized from a fixed dp radius, but on a layout region shorter than that (e.g. some phone aspect ratios, where less vertical room is left below the D-Pad) the canvas couldn't fit the full circle, flattening its top and bottom edges instead of clipping evenly. Clamp the drawn (and touchable) circle to the view's own available space instead.

Adaptive Frame Pacing is now also available from the in-stream Quick Settings panel (Session tab, under Bitrate), not just the Settings screen. It's wired through the same pending-value + Apply + session restart flow as Resolution/Bitrate/Codec, since it's baked into the native video decoder at session-create time with no live-update path (confirmed via android_chiaki_video_decoder_init in video-decoder.c) — a plain instant switch would show the new value without it actually taking effect. Also fixed restartRemotePlaySession() to carry the current adaptiveFramePacingEnabled preference into the restart, which it was silently dropping even for the existing Settings-screen toggle.

The performance overlay gains an "AFP" status line (Full and Minimal modes) sourced from the live session's actual connectInfo rather than the raw preference, so it only flips once a restart has genuinely swapped in the new session instead of the instant Apply is tapped.