### PR TITLE
Stop excluding MGS Master Collection bonus content from the PS5 library

### DIFF
--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -16,8 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RELEASE_NOTES: |-
-        - Fixed Star Wars: The Force Unleashed - Ultimate Sith Edition (and other titles with a similar multi-word edition suffix) not finding its trophies — Sony's trophy title omits the edition suffix entirely, and the matcher previously only recognized a single-word edition tier (e.g. "Digital Edition"), not a branded one like "Ultimate Sith Edition".
-        - Fixed inFAMOUS: Festival of Blood not finding its trophies — the catalogue's "– Full Game" storefront suffix isn't an edition label, so it wasn't being stripped before matching against Sony's bare trophy title.
+        - Fixed Metal Gear Solid: Master Collection Vol.1 and Vol.2 "Bonus Content" being hidden from the PS5 library — it was wrongly caught by the generic bonus-content filter even though it bundles playable, streamable classic titles.
 
     steps:
       - name: Checkout repo

--- a/android/app/src/main/java/com/metallic/chiaki/cloudplay/api/PsCloudOwnership.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/cloudplay/api/PsCloudOwnership.kt
@@ -154,10 +154,20 @@ object PsCloudOwnership
 		Regex("^the\\s+art\\s+of\\s+", RegexOption.IGNORE_CASE), // "The Art of Starfield"-style artbook naming
 		Regex("soundtrack", RegexOption.IGNORE_CASE),
 		Regex("content\\s*viewer", RegexOption.IGNORE_CASE),
-		Regex("bonus\\s*content", RegexOption.IGNORE_CASE), // e.g. "METAL GEAR SOLID: MASTER COLLECTION Vol.1 BONUS CONTENT"
+		Regex("bonus\\s*content", RegexOption.IGNORE_CASE), // e.g. generic "... BONUS CONTENT" cosmetic-extras bundles
 	)
 
-	private fun isDigitalExtra(name: String): Boolean = DIGITAL_EXTRA_NAME_PATTERNS.any { it.containsMatchIn(name) }
+	// Unlike a typical "bonus content" entitlement (cosmetic extras, digital manuals), the Metal
+	// Gear Solid: Master Collection Vol.1/Vol.2 "BONUS CONTENT" entitlement actually bundles
+	// playable classic titles (e.g. the original Metal Gear/Metal Gear 2 MSX games), which are
+	// themselves streamable — so it must not be caught by the generic bonus-content filter above.
+	private val DIGITAL_EXTRA_EXCEPTIONS = listOf(
+		Regex("master\\s*collection.*bonus\\s*content", RegexOption.IGNORE_CASE)
+	)
+
+	private fun isDigitalExtra(name: String): Boolean =
+		DIGITAL_EXTRA_NAME_PATTERNS.any { it.containsMatchIn(name) } &&
+			DIGITAL_EXTRA_EXCEPTIONS.none { it.containsMatchIn(name) }
 
 	/**
 	 * Picks the identifier Gaikai actually validates against when an entitlement's own `id` and

--- a/android/app/src/test/java/com/metallic/chiaki/cloudplay/api/PsCloudOwnershipTest.kt
+++ b/android/app/src/test/java/com/metallic/chiaki/cloudplay/api/PsCloudOwnershipTest.kt
@@ -712,18 +712,44 @@ class PsCloudOwnershipTest {
 
     @Test
     fun `'BONUS CONTENT' naming style is excluded`() {
-        // Metal Gear Solid: Master Collection Vol.1-style: a separate entitlement literally named
-        // "... BONUS CONTENT", same PSGD/featureType=3 shape as a real game.
+        // A generic "... BONUS CONTENT" entitlement (cosmetic extras/digital manual), same
+        // PSGD/featureType=3 shape as a real game.
+        val ents = listOf(
+            entitlement(
+                id = "EP0101-PPSA16257_00-GENERICBONUSCONT",
+                productId = "EP0101-PPSA16257_00-GENERICBONUSCONT",
+                packageType = "PSGD",
+                name = "SOME GAME: DELUXE EDITION BONUS CONTENT"
+            )
+        )
+
+        assertTrue(PsCloudOwnership.buildOwnedGamesFromEntitlements(ents).isEmpty())
+    }
+
+    @Test
+    fun `Metal Gear Solid Master Collection 'BONUS CONTENT' is not excluded`() {
+        // Unlike a typical "BONUS CONTENT" entitlement, the MGS Master Collection Vol.1/Vol.2
+        // bonus content actually bundles playable classic titles, so it must still show up.
         val ents = listOf(
             entitlement(
                 id = "EP0101-PPSA16257_00-MGSBONUSCONTENTS",
                 productId = "EP0101-PPSA16257_00-MGSBONUSCONTENTS",
                 packageType = "PSGD",
                 name = "METAL GEAR SOLID: MASTER COLLECTION Vol.1 BONUS CONTENT"
+            ),
+            entitlement(
+                id = "EP0101-PPSA16258_00-MGSBONUSCONTENTS2",
+                productId = "EP0101-PPSA16258_00-MGSBONUSCONTENTS2",
+                packageType = "PSGD",
+                name = "METAL GEAR SOLID: MASTER COLLECTION Vol.2 BONUS CONTENT"
             )
         )
 
-        assertTrue(PsCloudOwnership.buildOwnedGamesFromEntitlements(ents).isEmpty())
+        val games = PsCloudOwnership.buildOwnedGamesFromEntitlements(ents)
+
+        assertEquals(2, games.size)
+        assertTrue(games.any { it.name == "METAL GEAR SOLID: MASTER COLLECTION Vol.1 BONUS CONTENT" })
+        assertTrue(games.any { it.name == "METAL GEAR SOLID: MASTER COLLECTION Vol.2 BONUS CONTENT" })
     }
 
     @Test


### PR DESCRIPTION
The generic "BONUS CONTENT" name filter was hiding the Metal Gear Solid: Master Collection Vol.1/Vol.2 bonus content entitlement, but unlike a typical bonus-content extra it actually bundles playable, streamable classic titles.